### PR TITLE
Add mobile support for climbing RPG

### DIFF
--- a/files.json
+++ b/files.json
@@ -4,126 +4,126 @@
       "name": "cindys_surf_adventure.html",
       "isDirectory": false,
       "size": 30076,
-      "modified": "2026-01-23T02:54:21.062Z",
+      "modified": "2026-01-24T15:59:27.314Z",
       "extension": ".html"
     },
     {
       "name": "climbing_rpg_prototype.html",
       "isDirectory": false,
-      "size": 141274,
-      "modified": "2026-01-23T02:54:21.063Z",
+      "size": 149389,
+      "modified": "2026-01-24T15:59:27.314Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v4_psychedelic.html",
       "isDirectory": false,
       "size": 36638,
-      "modified": "2026-01-23T02:54:21.063Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v5_complete.html",
       "isDirectory": false,
       "size": 60526,
-      "modified": "2026-01-23T02:54:21.063Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v1.html",
       "isDirectory": false,
       "size": 42222,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v2.html",
       "isDirectory": false,
       "size": 49116,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v3.html",
       "isDirectory": false,
       "size": 62150,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "glass-conductor-v3.html",
       "isDirectory": false,
       "size": 51483,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.315Z",
       "extension": ".html"
     },
     {
       "name": "glass_conductor_v4.html",
       "isDirectory": false,
       "size": 32549,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "glass_minimalist_composer.html",
       "isDirectory": false,
       "size": 23765,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "hatsune_shingyo.html",
       "isDirectory": false,
       "size": 11883,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "hrv_monitor.html",
       "isDirectory": false,
       "size": 16554,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "index.html",
       "isDirectory": false,
       "size": 10563,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "rocks.json",
       "isDirectory": false,
       "size": 5694,
-      "modified": "2026-01-23T02:54:21.064Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".json"
     },
     {
       "name": "sound_catcher.html",
       "isDirectory": false,
       "size": 83949,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "stress_relief_app.html",
       "isDirectory": false,
       "size": 36744,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "theremin_dual_sine_sorted.html",
       "isDirectory": false,
       "size": 8707,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.316Z",
       "extension": ".html"
     },
     {
       "name": "visual_eno_loops_universal.html",
       "isDirectory": false,
       "size": 26572,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.317Z",
       "extension": ".html"
     }
   ],
@@ -132,21 +132,21 @@
       "name": "prompt.py",
       "isDirectory": false,
       "size": 0,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.317Z",
       "extension": ".py"
     },
     {
       "name": "userinput.py",
       "isDirectory": false,
       "size": 30,
-      "modified": "2026-01-23T02:54:21.065Z",
+      "modified": "2026-01-24T15:59:27.317Z",
       "extension": ".py"
     },
     {
       "name": "vocal.mp3",
       "isDirectory": false,
       "size": 4869577,
-      "modified": "2026-01-23T02:54:21.086Z",
+      "modified": "2026-01-24T15:59:27.337Z",
       "extension": ".mp3"
     }
   ],
@@ -155,21 +155,21 @@
       "name": "project_structure.md",
       "isDirectory": false,
       "size": 11949,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.255Z",
       "extension": ".md"
     },
     {
       "name": "user_tasks.log",
       "isDirectory": false,
       "size": 285,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.255Z",
       "extension": ".log"
     },
     {
       "name": "vibes-README.md",
       "isDirectory": false,
       "size": 2879,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.255Z",
       "extension": ".md"
     }
   ],
@@ -178,35 +178,35 @@
       "name": "index.html",
       "isDirectory": false,
       "size": 9655,
-      "modified": "2026-01-23T02:54:21.010Z",
+      "modified": "2026-01-24T15:59:27.260Z",
       "extension": ".html"
     },
     {
       "name": "README.md",
       "isDirectory": false,
       "size": 1237,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.255Z",
       "extension": ".md"
     },
     {
       "name": "LICENSE",
       "isDirectory": false,
       "size": 35149,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.254Z",
       "extension": ""
     },
     {
       "name": "DEPLOYMENT.md",
       "isDirectory": false,
       "size": 3247,
-      "modified": "2026-01-23T02:54:21.006Z",
+      "modified": "2026-01-24T15:59:27.254Z",
       "extension": ".md"
     },
     {
       "name": "package.json",
       "isDirectory": false,
       "size": 579,
-      "modified": "2026-01-23T02:54:21.010Z",
+      "modified": "2026-01-24T15:59:27.260Z",
       "extension": ".json"
     }
   ]

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -536,27 +536,30 @@
 
         .effort-selection-mobile {
             display: flex;
-            gap: 10px;
+            gap: 8px;
             justify-content: center;
+            align-items: center;
             margin-top: 15px;
+            flex-wrap: wrap;
         }
 
         .effort-selection-mobile .effort-btn {
             flex: 1;
-            max-width: 150px;
+            max-width: 120px;
         }
 
-        /* Climber badge positioning */
-        .climber-badge {
-            position: absolute;
-            bottom: 12px;
-            left: 12px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
+        .effort-selection-mobile .climber-badge {
+            position: static;
             background: rgba(0, 0, 0, 0.7);
             padding: 6px 12px;
             border-radius: 20px;
+        }
+
+        /* Climber badge base styles */
+        .climber-badge {
+            display: flex;
+            align-items: center;
+            gap: 8px;
         }
 
         /* Route Editor (Dev Tool) */
@@ -1294,17 +1297,16 @@
             <div class="attempt-main">
                 <div class="attempt-canvas-container" id="attempt-canvas-container">
                     <canvas id="attempt-canvas" width="600" height="500"></canvas>
-                    <div class="climber-badge" id="climber-badge">
-                        <div class="climber-avatar-large" id="current-climber-avatar"></div>
-                        <span id="current-climber-name"></span>
-                        <span id="climber-stats-display" class="climber-stats-inline"></span>
-                    </div>
                 </div>
                 <div class="climb-progress-bar">
                     <div class="climb-progress-fill" id="climb-progress-fill"></div>
                 </div>
                 <div class="climb-progress-text" id="climb-progress-text">Select effort to climb</div>
                 <div class="effort-selection-mobile">
+                    <div class="climber-badge" id="climber-badge">
+                        <div class="climber-avatar-large" id="current-climber-avatar"></div>
+                        <span id="current-climber-name"></span>
+                    </div>
                     <button class="effort-btn casual" onclick="selectEffort('casual')">🧘 Casual</button>
                     <button class="effort-btn send" onclick="selectEffort('send')">🔥 Send</button>
                     <button class="effort-btn limit" onclick="selectEffort('limit')">⚡ Limit</button>

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -954,16 +954,27 @@
                 text-align: center;
             }
 
-            /* Crag view - stack vertically */
+            /* Crag view - stack vertically and allow scroll */
+            #crag-view {
+                overflow-y: auto;
+                -webkit-overflow-scrolling: touch;
+            }
+
             .crag-container {
+                flex: none;
                 flex-direction: column;
                 padding: 10px;
+                padding-bottom: 20px;
                 gap: 10px;
+                overflow: visible;
+                min-height: auto;
+                height: auto;
             }
 
             .rock-display {
                 flex: none;
-                max-height: 35vh;
+                max-height: 30vh;
+                min-height: 150px;
             }
 
             #rock-canvas {
@@ -974,8 +985,8 @@
             .problems-panel {
                 width: 100%;
                 max-height: none;
-                flex: 1;
-                min-height: 200px;
+                flex: none;
+                overflow: visible;
             }
 
             .problem-card {
@@ -983,6 +994,10 @@
                 margin-bottom: 10px;
                 /* Ensure 44px minimum touch target */
                 min-height: 44px;
+            }
+
+            #attempt-btn {
+                margin-bottom: 10px;
             }
 
             .crag-header {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -898,6 +898,295 @@
         #pixel-transition.active {
             display: block;
         }
+
+        /* ========== MOBILE RESPONSIVE STYLES ========== */
+
+        /* Prevent browser gestures on game screens */
+        body {
+            touch-action: pan-x pan-y;
+        }
+
+        #world-map,
+        #crag-view,
+        #attempt-phase {
+            touch-action: none;
+        }
+
+        /* Mobile breakpoint: < 768px */
+        @media screen and (max-width: 767px) {
+            /* Title screen adjustments */
+            .title {
+                font-size: 2rem;
+                padding: 0 20px;
+            }
+
+            .subtitle {
+                font-size: 1rem;
+                padding: 0 20px;
+            }
+
+            /* World map - hide party sidebar, use modal instead */
+            .party-sidebar {
+                display: none;
+            }
+
+            .map-header {
+                padding: 10px 15px;
+                flex-wrap: wrap;
+                gap: 10px;
+            }
+
+            .map-header h2 {
+                font-size: 1.1rem;
+            }
+
+            /* Movement hint update for touch */
+            .movement-hint {
+                font-size: 0.75rem;
+                padding: 6px 10px;
+            }
+
+            /* Nearby indicator - move above log panel */
+            .nearby-indicator {
+                bottom: 140px;
+                left: 10px;
+                right: 10px;
+                text-align: center;
+            }
+
+            /* Crag view - stack vertically */
+            .crag-container {
+                flex-direction: column;
+                padding: 10px;
+                gap: 10px;
+            }
+
+            .rock-display {
+                flex: none;
+                max-height: 35vh;
+            }
+
+            #rock-canvas {
+                max-height: 100%;
+                width: auto;
+            }
+
+            .problems-panel {
+                width: 100%;
+                max-height: none;
+                flex: 1;
+                min-height: 200px;
+            }
+
+            .problem-card {
+                padding: 12px;
+                margin-bottom: 10px;
+                /* Ensure 44px minimum touch target */
+                min-height: 44px;
+            }
+
+            .crag-header {
+                padding: 10px 15px;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            #rock-name {
+                font-size: 1.1rem !important;
+            }
+
+            /* Attempt phase - stack vertically */
+            .attempt-container {
+                flex-direction: column;
+                padding: 10px;
+                gap: 10px;
+            }
+
+            .attempt-main {
+                flex: none;
+            }
+
+            .attempt-canvas-container {
+                max-height: 40vh;
+            }
+
+            #attempt-canvas {
+                max-height: 100%;
+            }
+
+            .right-panel {
+                width: 100%;
+                flex-direction: row;
+                flex-wrap: wrap;
+            }
+
+            .attempt-stats {
+                flex: 1;
+                min-width: 150px;
+            }
+
+            .support-panel {
+                flex: 1;
+                min-width: 150px;
+                max-height: 200px;
+            }
+
+            .support-title {
+                font-size: 1rem;
+                margin-bottom: 10px;
+            }
+
+            .support-action {
+                padding: 10px;
+                min-height: 44px;
+            }
+
+            /* Effort buttons - larger touch targets */
+            .effort-overlay {
+                flex-direction: column;
+                gap: 8px;
+                bottom: 8px;
+                left: 8px;
+                right: 8px;
+            }
+
+            .effort-selection {
+                width: 100%;
+                justify-content: space-between;
+            }
+
+            .effort-btn {
+                flex: 1;
+                padding: 12px 8px;
+                font-size: 0.8rem;
+                min-height: 44px;
+            }
+
+            .climber-badge {
+                width: 100%;
+                justify-content: center;
+            }
+
+            /* Attempt header */
+            .attempt-header {
+                padding: 10px 15px;
+            }
+
+            #attempt-problem-name {
+                font-size: 1.1rem !important;
+            }
+
+            /* Commit button */
+            #commit-btn {
+                min-height: 48px;
+                font-size: 1rem;
+            }
+
+            /* Log panel - smaller on mobile */
+            .log-panel {
+                height: 80px;
+                font-size: 0.75rem;
+                padding: 8px 15px;
+            }
+
+            /* Adjust screen padding for smaller log */
+            .screen {
+                padding-bottom: 90px;
+            }
+
+            /* Modal adjustments */
+            .modal {
+                margin: 20px;
+                padding: 25px;
+                max-width: calc(100vw - 40px);
+            }
+
+            .result-icon {
+                font-size: 3rem;
+            }
+
+            .result-title {
+                font-size: 1.5rem;
+            }
+
+            /* Buttons - ensure touch targets */
+            .btn {
+                min-height: 44px;
+                padding: 12px 24px;
+            }
+
+            /* Rock cleared overlay */
+            .rock-cleared {
+                padding: 20px 30px;
+                font-size: 1.5rem;
+            }
+        }
+
+        /* Small mobile: < 480px */
+        @media screen and (max-width: 479px) {
+            .title {
+                font-size: 1.75rem;
+            }
+
+            .attempt-canvas-container {
+                max-height: 35vh;
+            }
+
+            .right-panel {
+                flex-direction: column;
+            }
+
+            .attempt-stats,
+            .support-panel {
+                min-width: 100%;
+            }
+
+            .support-panel {
+                max-height: 150px;
+            }
+
+            .effort-btn {
+                padding: 10px 6px;
+                font-size: 0.75rem;
+            }
+
+            .stat-row {
+                font-size: 0.85rem;
+            }
+        }
+
+        /* Landscape phone - reduce heights */
+        @media screen and (max-height: 500px) and (orientation: landscape) {
+            .log-panel {
+                height: 50px;
+                font-size: 0.7rem;
+            }
+
+            .screen {
+                padding-bottom: 60px;
+            }
+
+            .rock-display {
+                max-height: 50vh;
+            }
+
+            .attempt-canvas-container {
+                max-height: 50vh;
+            }
+
+            .modal {
+                padding: 15px;
+            }
+
+            .result-icon {
+                font-size: 2rem;
+                margin-bottom: 10px;
+            }
+
+            .result-title {
+                font-size: 1.2rem;
+            }
+        }
     </style>
 </head>
 
@@ -930,14 +1219,14 @@
             <div class="party-sidebar" id="party-display"></div>
 
             <!-- Movement hint -->
-            <div class="movement-hint">
-                Click to move • Click on rock to climb
+            <div class="movement-hint" id="movement-hint">
+                Tap to move • Tap rock to climb
             </div>
 
             <!-- Nearby rock indicator -->
             <div class="nearby-indicator" id="nearby-indicator">
                 <div class="nearby-rock-name" id="nearby-rock-name"></div>
-                <div class="nearby-hint">Press ENTER or click rock to approach</div>
+                <div class="nearby-hint" id="nearby-hint">Tap rock to approach</div>
             </div>
 
                     </div>
@@ -1928,6 +2217,10 @@
             window.addEventListener('resize', resizeWorldCanvas);
             worldCanvas.addEventListener('click', handleMapClick);
 
+            // Touch support for mobile
+            worldCanvas.addEventListener('touchstart', handleMapTouch, { passive: false });
+            worldCanvas.addEventListener('touchmove', (e) => e.preventDefault(), { passive: false });
+
             // Keyboard controls
             window.addEventListener('keydown', handleKeyDown);
             window.addEventListener('keyup', handleKeyUp);
@@ -2449,7 +2742,7 @@
                 const rockPos = getRockPosition(rock);
                 const dx = x - rockPos.x;
                 const dy = y - rockPos.y;
-                if (Math.sqrt(dx * dx + dy * dy) < 40) {
+                if (Math.sqrt(dx * dx + dy * dy) < 50) { // Larger hitbox for touch
                     // Set target to walk to rock, store rock to enter on arrival
                     gameState.targetPosition = {
                         x: rockPos.x - 50,
@@ -2462,6 +2755,34 @@
 
             // Otherwise, walk to clicked location
             gameState.targetPosition = { x: x, y: y };
+        }
+
+        function handleMapTouch(e) {
+            e.preventDefault();
+            if (e.touches.length > 0) {
+                const touch = e.touches[0];
+                const rect = worldCanvas.getBoundingClientRect();
+                const x = (touch.clientX - rect.left) * (worldCanvas.width / rect.width);
+                const y = (touch.clientY - rect.top) * (worldCanvas.height / rect.height);
+
+                // Check if tapped on a rock - walk to it then enter
+                for (const rock of ROCKS) {
+                    const rockPos = getRockPosition(rock);
+                    const dx = x - rockPos.x;
+                    const dy = y - rockPos.y;
+                    if (Math.sqrt(dx * dx + dy * dy) < 50) { // Larger hitbox for touch
+                        gameState.targetPosition = {
+                            x: rockPos.x - 50,
+                            y: rockPos.y + 20,
+                            rock: rock
+                        };
+                        return;
+                    }
+                }
+
+                // Otherwise, walk to tapped location
+                gameState.targetPosition = { x: x, y: y };
+            }
         }
 
         function updateRocksCleared() {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -978,7 +978,7 @@
             .problems-panel {
                 width: 100%;
                 flex: none;
-                padding-bottom: 20px;
+                margin-bottom: 100px;
             }
 
             .problem-card {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -908,7 +908,7 @@
 
         #crag-view,
         #attempt-phase {
-            touch-action: pan-y;
+            touch-action: auto;
         }
 
         /* Mobile breakpoint: < 768px */
@@ -958,8 +958,10 @@
                 flex-direction: column;
                 padding: 10px;
                 gap: 10px;
-                overflow-y: scroll;
+                overflow-y: scroll !important;
                 -webkit-overflow-scrolling: touch;
+                touch-action: pan-y;
+                overscroll-behavior: contain;
             }
 
             .rock-display {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -979,7 +979,7 @@
                 width: 100%;
                 flex: none;
                 overflow: visible;
-                padding-bottom: 120px;
+                padding-bottom: 60px;
             }
 
             .problem-card {
@@ -1105,16 +1105,17 @@
                 font-size: 1rem;
             }
 
-            /* Log panel - smaller on mobile */
+            /* Log panel - minimal on mobile */
             .log-panel {
-                height: 80px;
-                font-size: 0.75rem;
-                padding: 8px 15px;
+                height: 40px;
+                font-size: 0.7rem;
+                padding: 5px 10px;
+                overflow: hidden;
             }
 
             /* Adjust screen padding for smaller log */
             .screen {
-                padding-bottom: 90px;
+                padding-bottom: 50px;
             }
 
             /* Modal adjustments */

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -902,14 +902,13 @@
         /* ========== MOBILE RESPONSIVE STYLES ========== */
 
         /* Prevent browser gestures on game screens */
-        body {
-            touch-action: pan-x pan-y;
+        #world-map {
+            touch-action: none;
         }
 
-        #world-map,
         #crag-view,
         #attempt-phase {
-            touch-action: none;
+            touch-action: pan-y;
         }
 
         /* Mobile breakpoint: < 768px */

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -978,7 +978,8 @@
             .problems-panel {
                 width: 100%;
                 flex: none;
-                margin-bottom: 100px;
+                overflow: visible;
+                padding-bottom: 120px;
             }
 
             .problem-card {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -953,21 +953,13 @@
                 text-align: center;
             }
 
-            /* Crag view - stack vertically and allow scroll */
-            #crag-view {
-                overflow-y: auto;
-                -webkit-overflow-scrolling: touch;
-            }
-
+            /* Crag view - stack vertically and scroll */
             .crag-container {
-                flex: none;
                 flex-direction: column;
                 padding: 10px;
-                padding-bottom: 20px;
                 gap: 10px;
-                overflow: visible;
-                min-height: auto;
-                height: auto;
+                overflow-y: scroll;
+                -webkit-overflow-scrolling: touch;
             }
 
             .rock-display {
@@ -983,10 +975,8 @@
 
             .problems-panel {
                 width: 100%;
-                max-height: none;
                 flex: none;
-                overflow: visible;
-                padding-bottom: 100px;
+                padding-bottom: 20px;
             }
 
             .problem-card {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -1056,30 +1056,45 @@
                 min-height: 44px;
             }
 
-            /* Effort buttons - larger touch targets */
+            /* Effort buttons - compact row at bottom of canvas */
             .effort-overlay {
-                flex-direction: column;
-                gap: 8px;
+                flex-direction: row;
+                gap: 6px;
                 bottom: 8px;
                 left: 8px;
                 right: 8px;
-            }
-
-            .effort-selection {
-                width: 100%;
+                align-items: center;
                 justify-content: space-between;
             }
 
-            .effort-btn {
-                flex: 1;
-                padding: 12px 8px;
-                font-size: 0.8rem;
-                min-height: 44px;
+            .climber-badge {
+                flex: none;
+                padding: 4px 8px;
             }
 
-            .climber-badge {
-                width: 100%;
-                justify-content: center;
+            .climber-badge .climber-avatar-large {
+                width: 24px;
+                height: 24px;
+                font-size: 0.7rem;
+            }
+
+            .climber-badge #current-climber-name {
+                font-size: 0.8rem;
+            }
+
+            .climber-stats-inline {
+                display: none;
+            }
+
+            .effort-selection {
+                flex: none;
+                gap: 4px;
+            }
+
+            .effort-btn {
+                padding: 6px 10px;
+                font-size: 0.7rem;
+                min-height: 32px;
             }
 
             /* Attempt header */
@@ -1161,8 +1176,8 @@
             }
 
             .effort-btn {
-                padding: 10px 6px;
-                font-size: 0.75rem;
+                padding: 5px 8px;
+                font-size: 0.65rem;
             }
 
             .stat-row {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -987,6 +987,7 @@
                 max-height: none;
                 flex: none;
                 overflow: visible;
+                padding-bottom: 100px;
             }
 
             .problem-card {

--- a/synths/climbing_rpg_prototype.html
+++ b/synths/climbing_rpg_prototype.html
@@ -534,6 +534,31 @@
             color: #90a4ae;
         }
 
+        .effort-selection-mobile {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            margin-top: 15px;
+        }
+
+        .effort-selection-mobile .effort-btn {
+            flex: 1;
+            max-width: 150px;
+        }
+
+        /* Climber badge positioning */
+        .climber-badge {
+            position: absolute;
+            bottom: 12px;
+            left: 12px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            background: rgba(0, 0, 0, 0.7);
+            padding: 6px 12px;
+            border-radius: 20px;
+        }
+
         /* Route Editor (Dev Tool) */
         .route-editor-overlay {
             display: none;
@@ -1049,19 +1074,18 @@
                 min-height: 44px;
             }
 
-            /* Effort buttons - compact row at bottom of canvas */
-            .effort-overlay {
-                flex-direction: row;
-                gap: 6px;
-                bottom: 8px;
-                left: 8px;
-                right: 8px;
-                align-items: center;
-                justify-content: space-between;
+            /* Effort buttons below canvas on mobile */
+            .effort-selection-mobile {
+                margin-top: 10px;
+            }
+
+            .effort-selection-mobile .effort-btn {
+                padding: 12px 16px;
+                font-size: 0.9rem;
+                min-height: 44px;
             }
 
             .climber-badge {
-                flex: none;
                 padding: 4px 8px;
             }
 
@@ -1071,25 +1095,6 @@
                 font-size: 0.7rem;
             }
 
-            .climber-badge #current-climber-name {
-                font-size: 0.8rem;
-            }
-
-            .climber-stats-inline {
-                display: none;
-            }
-
-            .effort-selection {
-                flex: none;
-                gap: 4px;
-            }
-
-            .effort-btn {
-                padding: 6px 10px;
-                font-size: 0.7rem;
-                min-height: 32px;
-            }
-
             /* Attempt header */
             .attempt-header {
                 padding: 10px 15px;
@@ -1097,12 +1102,6 @@
 
             #attempt-problem-name {
                 font-size: 1.1rem !important;
-            }
-
-            /* Commit button */
-            #commit-btn {
-                min-height: 48px;
-                font-size: 1rem;
             }
 
             /* Log panel - minimal on mobile */
@@ -1295,26 +1294,21 @@
             <div class="attempt-main">
                 <div class="attempt-canvas-container" id="attempt-canvas-container">
                     <canvas id="attempt-canvas" width="600" height="500"></canvas>
-                    <div class="effort-overlay">
-                        <div class="climber-badge" id="climber-badge">
-                            <div class="climber-avatar-large" id="current-climber-avatar"></div>
-                            <span id="current-climber-name"></span>
-                            <span id="climber-stats-display" class="climber-stats-inline"></span>
-                        </div>
-                        <div class="effort-selection">
-                            <button class="effort-btn casual" onclick="selectEffort('casual')">🧘 Casual</button>
-                            <button class="effort-btn send" onclick="selectEffort('send')">🔥 Send</button>
-                            <button class="effort-btn limit" onclick="selectEffort('limit')">⚡ Limit</button>
-                        </div>
+                    <div class="climber-badge" id="climber-badge">
+                        <div class="climber-avatar-large" id="current-climber-avatar"></div>
+                        <span id="current-climber-name"></span>
+                        <span id="climber-stats-display" class="climber-stats-inline"></span>
                     </div>
                 </div>
                 <div class="climb-progress-bar">
                     <div class="climb-progress-fill" id="climb-progress-fill"></div>
                 </div>
-                <div class="climb-progress-text" id="climb-progress-text">Select effort and commit to climb</div>
-                <button class="btn" id="commit-btn" onclick="commitAttempt()" disabled style="margin-top: 10px;">
-                    Select Effort Level
-                </button>
+                <div class="climb-progress-text" id="climb-progress-text">Select effort to climb</div>
+                <div class="effort-selection-mobile">
+                    <button class="effort-btn casual" onclick="selectEffort('casual')">🧘 Casual</button>
+                    <button class="effort-btn send" onclick="selectEffort('send')">🔥 Send</button>
+                    <button class="effort-btn limit" onclick="selectEffort('limit')">⚡ Limit</button>
+                </div>
             </div>
 
             <div class="right-panel">
@@ -3292,19 +3286,13 @@
             updateOddsDisplay();
 
             // Update commit button
-            const commitBtn = document.getElementById('commit-btn');
-            if (gameState.selectedEffort) {
-                commitBtn.disabled = false;
-                commitBtn.textContent = `Commit (${gameState.selectedEffort.toUpperCase()})`;
-            } else {
-                commitBtn.disabled = true;
-                commitBtn.textContent = 'Select Effort Level';
-            }
         }
 
         function selectEffort(effort) {
             gameState.selectedEffort = effort;
             updateAttemptUI();
+            // Auto-start the attempt
+            commitAttempt();
         }
 
         function updateOddsDisplay() {
@@ -3492,10 +3480,6 @@
                 // Scale: rollDiff of 0 = 80%, rollDiff of 50+ = 20%
                 targetProgress = Math.max(20, Math.min(80, 80 - (rollDiff * 1.2)));
             }
-
-            // Disable commit button during animation
-            document.getElementById('commit-btn').disabled = true;
-            document.getElementById('commit-btn').textContent = 'Climbing...';
 
             // Start the climbing animation
             log(`${climber.name} starts the attempt...`, 'action');


### PR DESCRIPTION
- Add responsive CSS with media queries for mobile (<768px) and small
  mobile (<480px) breakpoints
- Stack crag view and attempt phase layouts vertically on mobile
- Convert fixed-width panels to full-width on mobile
- Add touch event handler for world map (tap-to-move)
- Increase rock tap hitbox from 40px to 50px for easier touch targeting
- Ensure 44px minimum touch targets on buttons and interactive elements
- Reduce log panel height on mobile to save screen space
- Add touch-action CSS to prevent unwanted browser gestures
- Update movement hints to use "tap" terminology
- Add landscape phone handling with reduced UI heights