### PR TITLE
Add Claude sessions dashboard

### DIFF
--- a/files.json
+++ b/files.json
@@ -4,133 +4,133 @@
       "name": "cindys_surf_adventure.html",
       "isDirectory": false,
       "size": 30076,
-      "modified": "2026-03-24T18:51:25.677Z",
+      "modified": "2026-03-24T18:56:38.410Z",
       "extension": ".html"
     },
     {
       "name": "climbing_rpg_prototype.html",
       "isDirectory": false,
       "size": 148763,
-      "modified": "2026-03-24T18:51:25.678Z",
+      "modified": "2026-03-24T18:56:38.410Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v4_psychedelic.html",
       "isDirectory": false,
       "size": 36638,
-      "modified": "2026-03-24T18:51:25.678Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v5_complete.html",
       "isDirectory": false,
       "size": 60526,
-      "modified": "2026-03-24T18:51:25.678Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v1.html",
       "isDirectory": false,
       "size": 42222,
-      "modified": "2026-03-24T18:51:25.678Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v2.html",
       "isDirectory": false,
       "size": 49116,
-      "modified": "2026-03-24T18:51:25.678Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v3.html",
       "isDirectory": false,
       "size": 62150,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "glass-conductor-v3.html",
       "isDirectory": false,
       "size": 51483,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.411Z",
       "extension": ".html"
     },
     {
       "name": "glass_conductor_v4.html",
       "isDirectory": false,
       "size": 32549,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "glass_minimalist_composer.html",
       "isDirectory": false,
       "size": 23765,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "hatsune_shingyo.html",
       "isDirectory": false,
       "size": 11883,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "hausu_birthday.html",
       "isDirectory": false,
       "size": 50096,
-      "modified": "2026-03-24T18:51:25.679Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "hrv_monitor.html",
       "isDirectory": false,
       "size": 16554,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "index.html",
       "isDirectory": false,
       "size": 10563,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".html"
     },
     {
       "name": "rocks.json",
       "isDirectory": false,
       "size": 5694,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.412Z",
       "extension": ".json"
     },
     {
       "name": "sound_catcher.html",
       "isDirectory": false,
       "size": 83949,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.413Z",
       "extension": ".html"
     },
     {
       "name": "stress_relief_app.html",
       "isDirectory": false,
       "size": 36744,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.413Z",
       "extension": ".html"
     },
     {
       "name": "theremin_dual_sine_sorted.html",
       "isDirectory": false,
       "size": 8707,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.413Z",
       "extension": ".html"
     },
     {
       "name": "visual_eno_loops_universal.html",
       "isDirectory": false,
       "size": 26572,
-      "modified": "2026-03-24T18:51:25.680Z",
+      "modified": "2026-03-24T18:56:38.413Z",
       "extension": ".html"
     }
   ],
@@ -139,35 +139,35 @@
       "name": "README.md",
       "isDirectory": false,
       "size": 993,
-      "modified": "2026-03-24T18:51:25.681Z",
+      "modified": "2026-03-24T18:56:38.413Z",
       "extension": ".md"
     },
     {
       "name": "claude_sessions_dashboard.py",
       "isDirectory": false,
-      "size": 19391,
-      "modified": "2026-03-24T18:51:25.681Z",
+      "size": 19445,
+      "modified": "2026-03-24T18:56:38.415Z",
       "extension": ".py"
     },
     {
       "name": "prompt.py",
       "isDirectory": false,
       "size": 0,
-      "modified": "2026-03-24T18:51:25.681Z",
+      "modified": "2026-03-24T18:56:38.415Z",
       "extension": ".py"
     },
     {
       "name": "userinput.py",
       "isDirectory": false,
       "size": 30,
-      "modified": "2026-03-24T18:51:25.681Z",
+      "modified": "2026-03-24T18:56:38.415Z",
       "extension": ".py"
     },
     {
       "name": "vocal.mp3",
       "isDirectory": false,
       "size": 4869577,
-      "modified": "2026-03-24T18:51:25.703Z",
+      "modified": "2026-03-24T18:56:38.434Z",
       "extension": ".mp3"
     }
   ],
@@ -176,21 +176,21 @@
       "name": "project_structure.md",
       "isDirectory": false,
       "size": 11949,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ".md"
     },
     {
       "name": "user_tasks.log",
       "isDirectory": false,
       "size": 285,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ".log"
     },
     {
       "name": "vibes-README.md",
       "isDirectory": false,
       "size": 2879,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ".md"
     }
   ],
@@ -199,35 +199,35 @@
       "name": "index.html",
       "isDirectory": false,
       "size": 9655,
-      "modified": "2026-03-24T18:51:25.625Z",
+      "modified": "2026-03-24T18:56:38.364Z",
       "extension": ".html"
     },
     {
       "name": "README.md",
       "isDirectory": false,
       "size": 1237,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ".md"
     },
     {
       "name": "LICENSE",
       "isDirectory": false,
       "size": 35149,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ""
     },
     {
       "name": "DEPLOYMENT.md",
       "isDirectory": false,
       "size": 3247,
-      "modified": "2026-03-24T18:51:25.619Z",
+      "modified": "2026-03-24T18:56:38.359Z",
       "extension": ".md"
     },
     {
       "name": "package.json",
       "isDirectory": false,
       "size": 579,
-      "modified": "2026-03-24T18:51:25.625Z",
+      "modified": "2026-03-24T18:56:38.364Z",
       "extension": ".json"
     }
   ]

--- a/files.json
+++ b/files.json
@@ -4,156 +4,163 @@
       "name": "cindys_surf_adventure.html",
       "isDirectory": false,
       "size": 30076,
-      "modified": "2026-03-16T01:11:01.925Z",
+      "modified": "2026-03-24T18:43:18.333Z",
       "extension": ".html"
     },
     {
       "name": "climbing_rpg_prototype.html",
       "isDirectory": false,
       "size": 148763,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v4_psychedelic.html",
       "isDirectory": false,
       "size": 36638,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v5_complete.html",
       "isDirectory": false,
       "size": 60526,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v1.html",
       "isDirectory": false,
       "size": 42222,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v2.html",
       "isDirectory": false,
       "size": 49116,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v3.html",
       "isDirectory": false,
       "size": 62150,
-      "modified": "2026-03-16T01:11:01.926Z",
+      "modified": "2026-03-24T18:43:18.334Z",
       "extension": ".html"
     },
     {
       "name": "glass-conductor-v3.html",
       "isDirectory": false,
       "size": 51483,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "glass_conductor_v4.html",
       "isDirectory": false,
       "size": 32549,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "glass_minimalist_composer.html",
       "isDirectory": false,
       "size": 23765,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "hatsune_shingyo.html",
       "isDirectory": false,
       "size": 11883,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "hausu_birthday.html",
       "isDirectory": false,
       "size": 50096,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "hrv_monitor.html",
       "isDirectory": false,
       "size": 16554,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "index.html",
       "isDirectory": false,
       "size": 10563,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".html"
     },
     {
       "name": "rocks.json",
       "isDirectory": false,
       "size": 5694,
-      "modified": "2026-03-16T01:11:01.927Z",
+      "modified": "2026-03-24T18:43:18.335Z",
       "extension": ".json"
     },
     {
       "name": "sound_catcher.html",
       "isDirectory": false,
       "size": 83949,
-      "modified": "2026-03-16T01:11:01.928Z",
+      "modified": "2026-03-24T18:43:18.336Z",
       "extension": ".html"
     },
     {
       "name": "stress_relief_app.html",
       "isDirectory": false,
       "size": 36744,
-      "modified": "2026-03-16T01:11:01.928Z",
+      "modified": "2026-03-24T18:43:18.336Z",
       "extension": ".html"
     },
     {
       "name": "theremin_dual_sine_sorted.html",
       "isDirectory": false,
       "size": 8707,
-      "modified": "2026-03-16T01:11:01.928Z",
+      "modified": "2026-03-24T18:43:18.336Z",
       "extension": ".html"
     },
     {
       "name": "visual_eno_loops_universal.html",
       "isDirectory": false,
       "size": 26572,
-      "modified": "2026-03-16T01:11:01.928Z",
+      "modified": "2026-03-24T18:43:18.336Z",
       "extension": ".html"
     }
   ],
   "tools": [
     {
+      "name": "claude_sessions_dashboard.py",
+      "isDirectory": false,
+      "size": 19391,
+      "modified": "2026-03-24T18:43:18.336Z",
+      "extension": ".py"
+    },
+    {
       "name": "prompt.py",
       "isDirectory": false,
       "size": 0,
-      "modified": "2026-03-16T01:11:01.928Z",
+      "modified": "2026-03-24T18:43:18.336Z",
       "extension": ".py"
     },
     {
       "name": "userinput.py",
       "isDirectory": false,
       "size": 30,
-      "modified": "2026-03-16T01:11:01.929Z",
+      "modified": "2026-03-24T18:43:18.338Z",
       "extension": ".py"
     },
     {
       "name": "vocal.mp3",
       "isDirectory": false,
       "size": 4869577,
-      "modified": "2026-03-16T01:11:01.949Z",
+      "modified": "2026-03-24T18:43:18.357Z",
       "extension": ".mp3"
     }
   ],
@@ -162,21 +169,21 @@
       "name": "project_structure.md",
       "isDirectory": false,
       "size": 11949,
-      "modified": "2026-03-16T01:11:01.873Z",
+      "modified": "2026-03-24T18:43:18.282Z",
       "extension": ".md"
     },
     {
       "name": "user_tasks.log",
       "isDirectory": false,
       "size": 285,
-      "modified": "2026-03-16T01:11:01.874Z",
+      "modified": "2026-03-24T18:43:18.283Z",
       "extension": ".log"
     },
     {
       "name": "vibes-README.md",
       "isDirectory": false,
       "size": 2879,
-      "modified": "2026-03-16T01:11:01.874Z",
+      "modified": "2026-03-24T18:43:18.283Z",
       "extension": ".md"
     }
   ],
@@ -185,35 +192,35 @@
       "name": "index.html",
       "isDirectory": false,
       "size": 9655,
-      "modified": "2026-03-16T01:11:01.879Z",
+      "modified": "2026-03-24T18:43:18.287Z",
       "extension": ".html"
     },
     {
       "name": "README.md",
       "isDirectory": false,
       "size": 1237,
-      "modified": "2026-03-16T01:11:01.873Z",
+      "modified": "2026-03-24T18:43:18.282Z",
       "extension": ".md"
     },
     {
       "name": "LICENSE",
       "isDirectory": false,
       "size": 35149,
-      "modified": "2026-03-16T01:11:01.873Z",
+      "modified": "2026-03-24T18:43:18.282Z",
       "extension": ""
     },
     {
       "name": "DEPLOYMENT.md",
       "isDirectory": false,
       "size": 3247,
-      "modified": "2026-03-16T01:11:01.873Z",
+      "modified": "2026-03-24T18:43:18.282Z",
       "extension": ".md"
     },
     {
       "name": "package.json",
       "isDirectory": false,
       "size": 579,
-      "modified": "2026-03-16T01:11:01.879Z",
+      "modified": "2026-03-24T18:43:18.287Z",
       "extension": ".json"
     }
   ]

--- a/files.json
+++ b/files.json
@@ -4,163 +4,170 @@
       "name": "cindys_surf_adventure.html",
       "isDirectory": false,
       "size": 30076,
-      "modified": "2026-03-24T18:43:18.333Z",
+      "modified": "2026-03-24T18:51:25.677Z",
       "extension": ".html"
     },
     {
       "name": "climbing_rpg_prototype.html",
       "isDirectory": false,
       "size": 148763,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.678Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v4_psychedelic.html",
       "isDirectory": false,
       "size": 36638,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.678Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v5_complete.html",
       "isDirectory": false,
       "size": 60526,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.678Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v1.html",
       "isDirectory": false,
       "size": 42222,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.678Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v2.html",
       "isDirectory": false,
       "size": 49116,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.678Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v3.html",
       "isDirectory": false,
       "size": 62150,
-      "modified": "2026-03-24T18:43:18.334Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "glass-conductor-v3.html",
       "isDirectory": false,
       "size": 51483,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "glass_conductor_v4.html",
       "isDirectory": false,
       "size": 32549,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "glass_minimalist_composer.html",
       "isDirectory": false,
       "size": 23765,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "hatsune_shingyo.html",
       "isDirectory": false,
       "size": 11883,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "hausu_birthday.html",
       "isDirectory": false,
       "size": 50096,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.679Z",
       "extension": ".html"
     },
     {
       "name": "hrv_monitor.html",
       "isDirectory": false,
       "size": 16554,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     },
     {
       "name": "index.html",
       "isDirectory": false,
       "size": 10563,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     },
     {
       "name": "rocks.json",
       "isDirectory": false,
       "size": 5694,
-      "modified": "2026-03-24T18:43:18.335Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".json"
     },
     {
       "name": "sound_catcher.html",
       "isDirectory": false,
       "size": 83949,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     },
     {
       "name": "stress_relief_app.html",
       "isDirectory": false,
       "size": 36744,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     },
     {
       "name": "theremin_dual_sine_sorted.html",
       "isDirectory": false,
       "size": 8707,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     },
     {
       "name": "visual_eno_loops_universal.html",
       "isDirectory": false,
       "size": 26572,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.680Z",
       "extension": ".html"
     }
   ],
   "tools": [
     {
+      "name": "README.md",
+      "isDirectory": false,
+      "size": 993,
+      "modified": "2026-03-24T18:51:25.681Z",
+      "extension": ".md"
+    },
+    {
       "name": "claude_sessions_dashboard.py",
       "isDirectory": false,
       "size": 19391,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.681Z",
       "extension": ".py"
     },
     {
       "name": "prompt.py",
       "isDirectory": false,
       "size": 0,
-      "modified": "2026-03-24T18:43:18.336Z",
+      "modified": "2026-03-24T18:51:25.681Z",
       "extension": ".py"
     },
     {
       "name": "userinput.py",
       "isDirectory": false,
       "size": 30,
-      "modified": "2026-03-24T18:43:18.338Z",
+      "modified": "2026-03-24T18:51:25.681Z",
       "extension": ".py"
     },
     {
       "name": "vocal.mp3",
       "isDirectory": false,
       "size": 4869577,
-      "modified": "2026-03-24T18:43:18.357Z",
+      "modified": "2026-03-24T18:51:25.703Z",
       "extension": ".mp3"
     }
   ],
@@ -169,21 +176,21 @@
       "name": "project_structure.md",
       "isDirectory": false,
       "size": 11949,
-      "modified": "2026-03-24T18:43:18.282Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ".md"
     },
     {
       "name": "user_tasks.log",
       "isDirectory": false,
       "size": 285,
-      "modified": "2026-03-24T18:43:18.283Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ".log"
     },
     {
       "name": "vibes-README.md",
       "isDirectory": false,
       "size": 2879,
-      "modified": "2026-03-24T18:43:18.283Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ".md"
     }
   ],
@@ -192,35 +199,35 @@
       "name": "index.html",
       "isDirectory": false,
       "size": 9655,
-      "modified": "2026-03-24T18:43:18.287Z",
+      "modified": "2026-03-24T18:51:25.625Z",
       "extension": ".html"
     },
     {
       "name": "README.md",
       "isDirectory": false,
       "size": 1237,
-      "modified": "2026-03-24T18:43:18.282Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ".md"
     },
     {
       "name": "LICENSE",
       "isDirectory": false,
       "size": 35149,
-      "modified": "2026-03-24T18:43:18.282Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ""
     },
     {
       "name": "DEPLOYMENT.md",
       "isDirectory": false,
       "size": 3247,
-      "modified": "2026-03-24T18:43:18.282Z",
+      "modified": "2026-03-24T18:51:25.619Z",
       "extension": ".md"
     },
     {
       "name": "package.json",
       "isDirectory": false,
       "size": 579,
-      "modified": "2026-03-24T18:43:18.287Z",
+      "modified": "2026-03-24T18:51:25.625Z",
       "extension": ".json"
     }
   ]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,41 @@
+# Tools
+
+## Claude Sessions Dashboard
+
+A local web UI for browsing your Claude Code session history. Zero dependencies — just Python 3.6+.
+
+### Prerequisites
+
+- Python 3.6+ (pre-installed on macOS and most Linux distros)
+- [Claude Code](https://claude.ai/code) installed (the dashboard reads from `~/.claude/projects/`)
+
+### Install & Run
+
+**Option 1: Download and run the script directly**
+
+```bash
+curl -O https://raw.githubusercontent.com/jnakagawa/vibes/main/tools/claude_sessions_dashboard.py
+python3 claude_sessions_dashboard.py
+```
+
+**Option 2: Clone the repo**
+
+```bash
+git clone https://github.com/jnakagawa/vibes.git
+python3 vibes/tools/claude_sessions_dashboard.py
+```
+
+Then open http://localhost:8484 in your browser.
+
+### Custom port
+
+```bash
+python3 claude_sessions_dashboard.py 9090
+```
+
+### Features
+
+- Search and filter sessions by project, branch, or content
+- Preview session messages inline
+- Copy `claude --resume` commands to clipboard
+- Auto-refreshes every 5 seconds

--- a/tools/claude_sessions_dashboard.py
+++ b/tools/claude_sessions_dashboard.py
@@ -294,6 +294,7 @@ function renderList() {
       <div class="row-summary">${esc(displayName(s))}</div>
       <div class="row-meta">
         ${s.gitBranch ? '<span class="branch-tag">' + esc(s.gitBranch) + '</span>' : ''}
+        <span>${(s.size / 1024).toFixed(0)} KB</span>
       </div>
     </div>`;
   }).join('');

--- a/tools/claude_sessions_dashboard.py
+++ b/tools/claude_sessions_dashboard.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Claude Sessions Dashboard — zero-dependency local web UI for browsing resumable sessions."""
+
+import json
+import os
+import re
+import sys
+import urllib.parse
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+PROJECTS_DIR = Path.home() / ".claude" / "projects"
+DEFAULT_PORT = 8484
+HEAD_BYTES = 8192  # first 8KB — enough for metadata + first prompt
+TAIL_BYTES = 4096  # last 4KB — summaries, titles, tags written at end
+
+
+def _extract_text(content):
+    """Pull plain text from message content (string or content-block list)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _grep_json_value(text, key):
+    """Fast regex extract of a JSON string value by key name (no full parse)."""
+    m = re.search(rf'"{key}"\s*:\s*"((?:[^"\\]|\\.)*)"', text)
+    return m.group(1) if m else None
+
+
+def _head_tail(path, size):
+    """Read the first HEAD_BYTES and last TAIL_BYTES of a file."""
+    with open(path, "rb") as f:
+        head = f.read(HEAD_BYTES).decode("utf-8", errors="replace")
+        if size > HEAD_BYTES + TAIL_BYTES:
+            f.seek(-TAIL_BYTES, 2)
+            tail = f.read().decode("utf-8", errors="replace")
+        elif size > HEAD_BYTES:
+            tail = head  # small file — head covers it all
+        else:
+            tail = head
+    return head, tail
+
+
+def _extract_first_prompt(head):
+    """Get the first user prompt text from the head bytes (regex, no full parse)."""
+    # Find first non-meta user message and extract its content text
+    # Look for "type":"user" lines that don't have "isMeta":true
+    for line in head.split("\n"):
+        if '"type":"user"' not in line and '"type": "user"' not in line:
+            continue
+        if '"isMeta":true' in line or '"isMeta": true' in line:
+            continue
+        # Try to extract content text
+        text = _grep_json_value(line, "text")
+        if text:
+            return text[:200]
+        content = _grep_json_value(line, "content")
+        if content:
+            return content[:200]
+    return ""
+
+
+def scan_sessions():
+    """Discover all sessions from JSONL files on disk using head+tail reads.
+    Mirrors Claude's internal lite scan approach — stat + partial reads only."""
+    if not PROJECTS_DIR.is_dir():
+        return []
+
+    sessions = []
+    for project_dir in PROJECTS_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        project_dir_name = project_dir.name
+        for jsonl in project_dir.iterdir():
+            if not jsonl.name.endswith(".jsonl") or not jsonl.is_file():
+                continue
+            try:
+                st = jsonl.stat()
+                size = st.st_size
+                if size < 50:
+                    continue
+                sid = jsonl.stem
+                head, tail = _head_tail(jsonl, size)
+
+                # Skip sidechains
+                if '"isSidechain":true' in head or '"isSidechain": true' in head:
+                    continue
+
+                first_prompt = _extract_first_prompt(head)
+                project_path = _grep_json_value(head, "cwd") or ""
+                git_branch = _grep_json_value(tail, "gitBranch") or _grep_json_value(head, "gitBranch") or ""
+                summary = _grep_json_value(tail, "summary") or ""
+                custom_title = _grep_json_value(tail, "customTitle") or ""
+
+                # Skip sessions with no real content
+                if not first_prompt and not summary and not custom_title:
+                    continue
+
+                project_name = os.path.basename(project_path) if project_path else project_dir_name
+
+                sessions.append({
+                    "sessionId": sid,
+                    "projectName": project_name,
+                    "projectPath": project_path,
+                    "gitBranch": git_branch,
+                    "firstPrompt": first_prompt,
+                    "summary": summary,
+                    "customTitle": custom_title,
+                    "mtime": st.st_mtime,
+                    "ctime": st.st_birthtime if hasattr(st, "st_birthtime") else st.st_ctime,
+                    "size": size,
+                })
+            except Exception:
+                continue
+
+    sessions.sort(key=lambda s: s["mtime"], reverse=True)
+    return sessions
+
+
+def read_session_messages(session_id):
+    """Read the JSONL file for a session and extract human-readable messages."""
+    for jsonl in PROJECTS_DIR.glob(f"*/{session_id}.jsonl"):
+        messages = []
+        try:
+            with open(jsonl) as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    msg_type = obj.get("type")
+                    if msg_type == "user" and not obj.get("isMeta"):
+                        content = obj.get("message", {}).get("content", "")
+                        text = _extract_text(content)
+                        if text.strip():
+                            messages.append({"role": "user", "text": text})
+                    elif msg_type == "assistant":
+                        content = obj.get("message", {}).get("content", [])
+                        text = _extract_text(content)
+                        if text.strip() and text != "(no content)":
+                            messages.append({"role": "assistant", "text": text})
+        except Exception:
+            pass
+        return messages
+    return []
+
+
+DASHBOARD_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Claude Sessions</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117;--surface:#161b22;--border:#30363d;
+  --text:#e6edf3;--dim:#8b949e;--accent:#58a6ff;
+  --green:#3fb950;--red:#f85149;--row-hover:#1c2128;
+  --user-bg:#1a2233;--asst-bg:#121820;
+}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;height:100vh;overflow:hidden;display:flex;flex-direction:column}
+
+.header{padding:12px 20px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:12px;flex-wrap:wrap;flex-shrink:0}
+.header h1{font-size:15px;font-weight:600;white-space:nowrap;font-family:'SF Mono',SFMono-Regular,Consolas,monospace}
+.status{width:8px;height:8px;border-radius:50%;display:inline-block;flex-shrink:0}
+.status.ok{background:var(--green)}.status.err{background:var(--red)}
+.controls{display:flex;gap:8px;flex:1;min-width:0;flex-wrap:wrap;align-items:center}
+input[type=text],select{background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:5px 10px;font-size:12px;outline:none;font-family:inherit}
+input[type=text]{flex:1;min-width:160px}
+input[type=text]:focus,select:focus{border-color:var(--accent)}
+select{min-width:130px}
+.count{color:var(--dim);font-size:11px;white-space:nowrap}
+.hide-sc label{color:var(--dim);font-size:12px;cursor:pointer;white-space:nowrap;display:flex;align-items:center;gap:4px}
+
+.main{flex:1;display:flex;overflow:hidden}
+
+.list-pane{width:420px;min-width:320px;max-width:500px;border-right:1px solid var(--border);overflow-y:auto;flex-shrink:0}
+.row{padding:10px 16px;border-bottom:1px solid var(--border);cursor:pointer;transition:background .1s}
+.row:hover{background:var(--row-hover)}
+.row.active{background:var(--row-hover);border-left:3px solid var(--accent);padding-left:13px}
+.row-top{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:2px}
+.row-project{color:var(--accent);font-weight:600;font-size:12px}
+.row-time{color:var(--dim);font-size:11px;white-space:nowrap}
+.row-summary{font-size:12px;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:2px}
+.row-meta{display:flex;gap:10px;color:var(--dim);font-size:11px;align-items:center}
+.branch-tag{font-size:10px;background:#1c2128;padding:0 5px;border-radius:3px;color:var(--dim)}
+
+.preview-pane{flex:1;display:flex;flex-direction:column;overflow:hidden}
+.preview-header{padding:12px 20px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;flex-shrink:0;gap:10px}
+.preview-title{font-weight:600;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.preview-actions{display:flex;gap:8px;flex-shrink:0;align-items:center}
+.btn{background:var(--accent);color:#0d1117;border:none;border-radius:5px;padding:5px 12px;font-family:inherit;font-size:11px;font-weight:600;cursor:pointer;white-space:nowrap;transition:opacity .15s}
+.btn:hover{opacity:.85}
+.btn.copied{background:var(--green)}
+
+.preview-body{flex:1;overflow-y:auto;padding:0}
+.empty-preview{display:flex;align-items:center;justify-content:center;height:100%;color:var(--dim);font-size:14px}
+
+.msg-group{padding:12px 20px;border-bottom:1px solid var(--border)}
+.msg-group.user{background:var(--user-bg)}
+.msg-group.assistant{background:var(--asst-bg)}
+.msg-role{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px}
+.msg-role.user{color:var(--accent)}
+.msg-role.assistant{color:var(--green)}
+.msg-text{font-family:'SF Mono',SFMono-Regular,Consolas,monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-word;color:var(--text)}
+.msg-divider{text-align:center;padding:8px 20px;color:var(--dim);font-size:11px;border-bottom:1px solid var(--border);background:var(--bg);cursor:pointer}
+.msg-divider:hover{color:var(--accent)}
+.preview-info{padding:12px 20px;border-bottom:1px solid var(--border);display:flex;gap:16px;color:var(--dim);font-size:12px;flex-wrap:wrap;flex-shrink:0}
+</style>
+</head>
+<body>
+<div class="header">
+  <span class="status" id="status"></span>
+  <h1>Claude Sessions</h1>
+  <div class="controls">
+    <input type="text" id="search" placeholder="Search sessions...">
+    <select id="projectFilter"><option value="">All projects</option></select>
+  </div>
+  <span class="count" id="count"></span>
+</div>
+<div class="main">
+  <div class="list-pane" id="listPane"></div>
+  <div class="preview-pane" id="previewPane">
+    <div class="empty-preview">Hover over a session to preview</div>
+  </div>
+</div>
+
+<script>
+let allSessions = [];
+let activeId = null;
+let hoveredId = null;
+let displayedId = null;
+let msgCache = {};
+let expandedFull = {};
+
+const listPane = document.getElementById('listPane');
+const previewPane = document.getElementById('previewPane');
+const search = document.getElementById('search');
+const projectFilter = document.getElementById('projectFilter');
+const statusDot = document.getElementById('status');
+const countEl = document.getElementById('count');
+
+function relTime(ts) {
+  if (!ts) return '';
+  let ms = typeof ts === 'number' ? (ts > 1e12 ? ts : ts * 1000) : new Date(ts).getTime();
+  const diff = (Date.now() - ms) / 1000;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return Math.floor(diff) + 's ago';
+  if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+  if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+  if (diff < 2592000) return Math.floor(diff / 86400) + 'd ago';
+  return new Date(ms).toLocaleDateString();
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s || '';
+  return d.innerHTML;
+}
+
+function displayName(s) {
+  return s.customTitle || s.summary || s.firstPrompt || s.sessionId.slice(0, 8);
+}
+
+function renderList() {
+  const q = search.value.toLowerCase();
+  const proj = projectFilter.value;
+  const filtered = allSessions.filter(s => {
+    if (proj && s.projectName !== proj) return false;
+    if (q) {
+      const hay = [s.summary||'', s.customTitle||'', s.firstPrompt||'', s.projectName||'', s.gitBranch||''].join(' ').toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+  countEl.textContent = filtered.length + ' / ' + allSessions.length;
+  listPane.innerHTML = filtered.map(s => {
+    const isActive = s.sessionId === (activeId || hoveredId);
+    return `<div class="row${isActive ? ' active' : ''}" data-sid="${s.sessionId}"
+                 onmouseenter="onRowHover('${s.sessionId}')"
+                 onclick="onRowClick('${s.sessionId}')">
+      <div class="row-top">
+        <span class="row-project">${esc(s.projectName)}</span>
+        <span class="row-time">${relTime(s.mtime)}</span>
+      </div>
+      <div class="row-summary">${esc(displayName(s))}</div>
+      <div class="row-meta">
+        ${s.gitBranch ? '<span class="branch-tag">' + esc(s.gitBranch) + '</span>' : ''}
+      </div>
+    </div>`;
+  }).join('');
+}
+
+function showPreview(sessionId) {
+  if (!sessionId) {
+    previewPane.innerHTML = '<div class="empty-preview">Hover over a session to preview</div>';
+    displayedId = null;
+    return;
+  }
+  if (sessionId === displayedId) return;
+  displayedId = sessionId;
+
+  const s = allSessions.find(x => x.sessionId === sessionId);
+  if (!s) return;
+
+  const cmd = (s.projectPath ? 'cd ' + s.projectPath + ' && ' : '') + 'claude --resume ' + s.sessionId;
+  const cmdEsc = cmd.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+
+  previewPane.innerHTML = `
+    <div class="preview-header">
+      <span class="preview-title">${esc(displayName(s))}</span>
+      <div class="preview-actions">
+        <button class="btn" onclick="copyCmd(this, \`${cmdEsc}\`)">Copy resume cmd</button>
+      </div>
+    </div>
+    <div class="preview-info">
+      <span>${esc(s.projectName)}</span>
+      ${s.gitBranch ? '<span>branch: ' + esc(s.gitBranch) + '</span>' : ''}
+      <span>modified ${relTime(s.mtime)}</span>
+      <span>created ${relTime(s.ctime)}</span>
+      <span>${(s.size / 1024).toFixed(0)} KB</span>
+    </div>
+    <div class="preview-body" id="previewBody">
+      <div class="empty-preview" style="height:200px">Loading messages...</div>
+    </div>`;
+
+  if (msgCache[sessionId]) {
+    renderMessages(sessionId, msgCache[sessionId]);
+  } else {
+    fetch('/api/messages?id=' + sessionId)
+      .then(r => r.json())
+      .then(msgs => {
+        msgCache[sessionId] = msgs;
+        if (displayedId === sessionId) renderMessages(sessionId, msgs);
+      })
+      .catch(() => {
+        const body = document.getElementById('previewBody');
+        if (body && displayedId === sessionId) body.innerHTML = '<div class="empty-preview">Could not load messages</div>';
+      });
+  }
+}
+
+function renderMessages(sessionId, msgs) {
+  const body = document.getElementById('previewBody');
+  if (!body) return;
+  if (!msgs.length) {
+    body.innerHTML = '<div class="empty-preview">No messages in this session</div>';
+    return;
+  }
+
+  const PEEK = 3;
+  const full = expandedFull[sessionId];
+  const needsCollapse = msgs.length > PEEK * 2 + 1 && !full;
+
+  let toShow;
+  if (needsCollapse) {
+    const hiddenCount = msgs.length - PEEK * 2;
+    toShow = [
+      ...msgs.slice(0, PEEK),
+      { _divider: true, count: hiddenCount },
+      ...msgs.slice(-PEEK)
+    ];
+  } else {
+    toShow = msgs;
+  }
+
+  body.innerHTML = toShow.map(m => {
+    if (m._divider) {
+      return `<div class="msg-divider" onclick="expandAll('${sessionId}')">
+        ${m.count} more messages — click to show all
+      </div>`;
+    }
+    const maxLen = full ? Infinity : 2000;
+    const text = m.text.length > maxLen ? m.text.slice(0, maxLen) + '\n... (truncated)' : m.text;
+    return `<div class="msg-group ${m.role}">
+      <div class="msg-role ${m.role}">${m.role}</div>
+      <div class="msg-text">${esc(text)}</div>
+    </div>`;
+  }).join('');
+}
+
+function expandAll(sessionId) {
+  expandedFull[sessionId] = true;
+  if (msgCache[sessionId]) renderMessages(sessionId, msgCache[sessionId]);
+}
+
+let hoverTimer = null;
+function onRowHover(sid) {
+  if (activeId) return;
+  hoveredId = sid;
+  clearTimeout(hoverTimer);
+  hoverTimer = setTimeout(() => showPreview(sid), 80);
+  listPane.querySelectorAll('.row').forEach(r => r.classList.toggle('active', r.dataset.sid === sid));
+}
+
+function onRowClick(sid) {
+  if (activeId === sid) {
+    activeId = null;
+  } else {
+    activeId = sid;
+    hoveredId = sid;
+    showPreview(sid);
+  }
+  listPane.querySelectorAll('.row').forEach(r => r.classList.toggle('active', r.dataset.sid === (activeId || hoveredId)));
+}
+
+function copyCmd(btn, cmd) {
+  navigator.clipboard.writeText(cmd).then(() => {
+    btn.textContent = 'Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.textContent = 'Copy resume cmd'; btn.classList.remove('copied'); }, 1500);
+  });
+}
+
+function populateProjectFilter() {
+  const projects = [...new Set(allSessions.map(s => s.projectName))].sort();
+  const cur = projectFilter.value;
+  projectFilter.innerHTML = '<option value="">All projects</option>' +
+    projects.map(p => `<option value="${esc(p)}"${p === cur ? ' selected' : ''}>${esc(p)}</option>`).join('');
+}
+
+async function fetchSessions() {
+  try {
+    const res = await fetch('/api/sessions');
+    allSessions = await res.json();
+    statusDot.className = 'status ok';
+    populateProjectFilter();
+    renderList();
+  } catch (e) {
+    statusDot.className = 'status err';
+  }
+}
+
+search.addEventListener('input', renderList);
+projectFilter.addEventListener('change', renderList);
+
+listPane.addEventListener('mouseleave', () => {
+  if (!activeId) {
+    hoveredId = null;
+    clearTimeout(hoverTimer);
+  }
+});
+
+fetchSessions();
+setInterval(fetchSessions, 5000);
+</script>
+</body>
+</html>"""
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/api/sessions":
+            self._json_response(scan_sessions())
+        elif self.path.startswith("/api/messages"):
+            qs = urllib.parse.urlparse(self.path).query
+            params = urllib.parse.parse_qs(qs)
+            sid = params.get("id", [""])[0]
+            self._json_response(read_session_messages(sid) if sid else [])
+        elif self.path in ("/", "/index.html"):
+            page = DASHBOARD_HTML.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(page)))
+            self.end_headers()
+            self.wfile.write(page)
+        else:
+            self.send_error(404)
+
+    def _json_response(self, data):
+        body = json.dumps(data).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        if args and str(args[0]).startswith("4"):
+            super().log_message(fmt, *args)
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    print(f"Claude Sessions Dashboard running at http://localhost:{port}")
+    print("Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a zero-dependency Python web UI (`tools/claude_sessions_dashboard.py`) for browsing Claude Code session history
- Scans `~/.claude/projects/` JSONL files and serves a searchable, filterable dashboard on `localhost:8484`
- Features: session search, project filter, message preview, copy-to-clipboard resume commands

## Usage
```bash
python3 tools/claude_sessions_dashboard.py
```

## Test plan
- [ ] Run `python3 tools/claude_sessions_dashboard.py` and verify dashboard loads at http://localhost:8484
- [ ] Confirm sessions list populates and search/filter work
- [ ] Click a session and verify message preview renders
- [ ] Verify no private data is hardcoded in the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)