### PR TITLE
tune: matrix cam maxed defaults + mobile font

### DIFF
--- a/synths/matrix_ascii_cam.html
+++ b/synths/matrix_ascii_cam.html
@@ -56,10 +56,10 @@
   <div id="status">Click to start webcam</div>
   <div id="fps"></div>
   <div id="controls">
-    <label>Speed <input type="range" id="speed" min="0.2" max="3" step="0.1" value="1"></label>
-    <label>Trail <input type="range" id="trail" min="5" max="50" step="1" value="22"></label>
-    <label>Cam Mix <input type="range" id="cam-mix" min="0" max="1" step="0.05" value="0.8"></label>
-    <label>Edge Glow <input type="range" id="edge-glow" min="0" max="1" step="0.05" value="0.6"></label>
+    <label>Speed <input type="range" id="speed" min="0.2" max="6" step="0.1" value="3"></label>
+    <label>Trail <input type="range" id="trail" min="5" max="100" step="1" value="50"></label>
+    <label>Cam Mix <input type="range" id="cam-mix" min="0" max="2" step="0.05" value="1"></label>
+    <label>Edge Glow <input type="range" id="edge-glow" min="0" max="2" step="0.05" value="1"></label>
     <div style="display:flex;gap:6px;justify-content:center;margin-top:3px;flex-wrap:wrap">
       <button id="btn-mirror" class="active">Mirror</button>
       <button id="btn-cam">Cam Off</button>
@@ -74,11 +74,12 @@ const CHARS = (KATA + '0123456789').split('');
 
 const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
-let COLS, ROWS, CW, CH, FS = 11;
+let COLS, ROWS, CW, CH, FS;
 
 function resize() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
+  FS = canvas.width < 600 ? 7 : 11;
   CW = FS * 0.6;
   CH = FS + 1;
   COLS = Math.floor(canvas.width / CW);
@@ -87,8 +88,8 @@ function resize() {
 }
 
 // ── Rain — every column has a drop, always ──────────────────────────
-let drops = [], speedMul = 1, trailLen = 22, mirrorMode = true;
-let camMix = 0.8, edgeGlow = 0.6;
+let drops = [], speedMul = 3, trailLen = 50, mirrorMode = true;
+let camMix = 1, edgeGlow = 1;
 
 function makeDrop(x, rand) {
   const tl = trailLen + ((Math.random() * 12 - 6) | 0);


### PR DESCRIPTION
## Summary
- Default all sliders to max values with doubled ranges so they sit at midpoint
- Font size 7px on mobile (< 600px) for denser ASCII grid
- Speed 3, trail 50, cam mix 1, edge glow 1 as defaults

## Test plan
- [ ] Open on desktop — verify rain is fast/dense with strong cam influence
- [ ] Open on mobile — verify smaller font renders cleanly
- [ ] Sliders should start at midpoint with room to go higher or lower

🤖 Generated with [Claude Code](https://claude.com/claude-code)