### PR TITLE
Add jp-reader: Japanese photo → highlight → furigana + meaning

### DIFF
--- a/files.json
+++ b/files.json
@@ -4,140 +4,140 @@
       "name": "cindys_surf_adventure.html",
       "isDirectory": false,
       "size": 30076,
-      "modified": "2026-04-18T06:05:29.087Z",
+      "modified": "2026-06-24T21:44:12.456Z",
       "extension": ".html"
     },
     {
       "name": "climbing_rpg_prototype.html",
       "isDirectory": false,
       "size": 148763,
-      "modified": "2026-04-18T06:05:29.087Z",
+      "modified": "2026-06-24T21:44:12.457Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v4_psychedelic.html",
       "isDirectory": false,
       "size": 36638,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.457Z",
       "extension": ".html"
     },
     {
       "name": "enhanced_theremin_gestures_v5_complete.html",
       "isDirectory": false,
       "size": 60526,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.457Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v1.html",
       "isDirectory": false,
       "size": 42222,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v2.html",
       "isDirectory": false,
       "size": 49116,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "fm_synth_v3.html",
       "isDirectory": false,
       "size": 62150,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "glass-conductor-v3.html",
       "isDirectory": false,
       "size": 51483,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "glass_conductor_v4.html",
       "isDirectory": false,
       "size": 32549,
-      "modified": "2026-04-18T06:05:29.088Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "glass_minimalist_composer.html",
       "isDirectory": false,
       "size": 23765,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "hatsune_shingyo.html",
       "isDirectory": false,
       "size": 11883,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "hausu_birthday.html",
       "isDirectory": false,
       "size": 50096,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.458Z",
       "extension": ".html"
     },
     {
       "name": "hrv_monitor.html",
       "isDirectory": false,
       "size": 16554,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "index.html",
       "isDirectory": false,
       "size": 10563,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "matrix_ascii_cam.html",
       "isDirectory": false,
       "size": 18475,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "rocks.json",
       "isDirectory": false,
       "size": 5694,
-      "modified": "2026-04-18T06:05:29.089Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".json"
     },
     {
       "name": "sound_catcher.html",
       "isDirectory": false,
       "size": 109782,
-      "modified": "2026-04-18T06:05:29.090Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "stress_relief_app.html",
       "isDirectory": false,
       "size": 36744,
-      "modified": "2026-04-18T06:05:29.090Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "theremin_dual_sine_sorted.html",
       "isDirectory": false,
       "size": 8707,
-      "modified": "2026-04-18T06:05:29.090Z",
+      "modified": "2026-06-24T21:44:12.459Z",
       "extension": ".html"
     },
     {
       "name": "visual_eno_loops_universal.html",
       "isDirectory": false,
       "size": 26572,
-      "modified": "2026-04-18T06:05:29.090Z",
+      "modified": "2026-06-24T21:44:12.460Z",
       "extension": ".html"
     }
   ],
@@ -146,42 +146,42 @@
       "name": "README.md",
       "isDirectory": false,
       "size": 1039,
-      "modified": "2026-04-18T06:05:29.090Z",
+      "modified": "2026-06-24T21:44:12.460Z",
       "extension": ".md"
     },
     {
       "name": "claude_sessions_dashboard.py",
       "isDirectory": false,
       "size": 19445,
-      "modified": "2026-04-18T06:05:29.092Z",
+      "modified": "2026-06-24T21:44:12.461Z",
       "extension": ".py"
     },
     {
       "name": "prompt.py",
       "isDirectory": false,
       "size": 0,
-      "modified": "2026-04-18T06:05:29.092Z",
+      "modified": "2026-06-24T21:44:12.461Z",
       "extension": ".py"
     },
     {
       "name": "screenshot.png",
       "isDirectory": false,
       "size": 318176,
-      "modified": "2026-04-18T06:05:29.092Z",
+      "modified": "2026-06-24T21:44:12.461Z",
       "extension": ".png"
     },
     {
       "name": "userinput.py",
       "isDirectory": false,
       "size": 30,
-      "modified": "2026-04-18T06:05:29.092Z",
+      "modified": "2026-06-24T21:44:12.461Z",
       "extension": ".py"
     },
     {
       "name": "vocal.mp3",
       "isDirectory": false,
       "size": 4869577,
-      "modified": "2026-04-18T06:05:29.111Z",
+      "modified": "2026-06-24T21:44:12.480Z",
       "extension": ".mp3"
     }
   ],
@@ -190,21 +190,21 @@
       "name": "project_structure.md",
       "isDirectory": false,
       "size": 11949,
-      "modified": "2026-04-18T06:05:29.041Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ".md"
     },
     {
       "name": "user_tasks.log",
       "isDirectory": false,
       "size": 285,
-      "modified": "2026-04-18T06:05:29.042Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ".log"
     },
     {
       "name": "vibes-README.md",
       "isDirectory": false,
       "size": 2879,
-      "modified": "2026-04-18T06:05:29.042Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ".md"
     }
   ],
@@ -213,35 +213,35 @@
       "name": "index.html",
       "isDirectory": false,
       "size": 9655,
-      "modified": "2026-04-18T06:05:29.045Z",
+      "modified": "2026-06-24T21:44:12.414Z",
       "extension": ".html"
     },
     {
       "name": "README.md",
       "isDirectory": false,
       "size": 1237,
-      "modified": "2026-04-18T06:05:29.041Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ".md"
     },
     {
       "name": "LICENSE",
       "isDirectory": false,
       "size": 35149,
-      "modified": "2026-04-18T06:05:29.041Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ""
     },
     {
       "name": "DEPLOYMENT.md",
       "isDirectory": false,
       "size": 3247,
-      "modified": "2026-04-18T06:05:29.041Z",
+      "modified": "2026-06-24T21:44:12.410Z",
       "extension": ".md"
     },
     {
       "name": "package.json",
       "isDirectory": false,
       "size": 579,
-      "modified": "2026-04-18T06:05:29.045Z",
+      "modified": "2026-06-24T21:44:12.416Z",
       "extension": ".json"
     }
   ]

--- a/jp-reader/.env.example
+++ b/jp-reader/.env.example
@@ -1,0 +1,15 @@
+# OCR works out of the box on macOS via Apple Vision (local, free, no key).
+#
+# Set GOOGLE_API_KEY to (a) enable full-sentence translation via Google Translate,
+# and (b) make Google Cloud Vision available for OCR — better for VERTICAL Japanese
+# text (novels/manga) than Apple Vision.
+# The key must have "Cloud Translation API" (and "Cloud Vision API" for OCR) enabled.
+GOOGLE_API_KEY=
+
+# OCR engine override. Default: apple-vision on macOS, else google-vision if a key is
+# set, else the browser Tesseract.js fallback. Set OCR_ENGINE=google to force Google
+# Vision (e.g. for vertical text) even on macOS.
+# OCR_ENGINE=google
+
+# Port (default 3939)
+# PORT=3939

--- a/jp-reader/.gitignore
+++ b/jp-reader/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+bin/
+.env
+*.log
+.DS_Store

--- a/jp-reader/README.md
+++ b/jp-reader/README.md
@@ -1,0 +1,63 @@
+# 読む — Japanese Reader
+
+Photograph a page of Japanese, highlight any phrase, and get **furigana**, a
+**dictionary definition**, and a **natural translation**.
+
+Built for the phone: open it on your phone's browser, tap to use the camera,
+highlight a phrase in the recognized text, tap **Look up**.
+
+## How it works
+
+| Step | Engine |
+|------|--------|
+| OCR (photo → text) | **Apple Vision** (macOS, local, free, no key — default) → **Google Cloud Vision** if you set `GOOGLE_API_KEY` → in-browser **Tesseract.js** last-resort fallback |
+| Furigana (readings) | **kuromoji** morphological analysis, runs locally, okurigana-aware ruby |
+| Word definitions | **Jisho / JMdict** dictionary lookup |
+| Sentence translation | **Google Translate API** (the "if possible" part — used automatically when a key is set) |
+
+Interaction: drag a finger across the recognized text — the reading floats above the
+phrase, the meaning below — and lift to dismiss. Tap **Edit** to fix any OCR slip.
+
+### A note on OCR engines
+
+- **Apple Vision** (default on macOS) reads both **horizontal and vertical** Japanese
+  (textbooks, signs, novels, manga), fully local and free. It uses the modern
+  `RecognizeTextRequest` API (macOS 15+), which is what powers system Live Text.
+- The Apple Vision helper is a tiny Swift binary at `bin/mac-ocr`, built automatically by
+  `npm install` (or `npm run build`). Requires the Xcode command-line tools (`swiftc`).
+- `GOOGLE_API_KEY` (or `OCR_ENGINE=google`) switches OCR to Google Cloud Vision and also
+  enables full-sentence translation.
+
+## Run
+
+```bash
+npm install
+# optional — enables Google Vision OCR + Translate:
+export GOOGLE_API_KEY=your_key_here
+npm start
+```
+
+Then open **http://localhost:3939**.
+
+### Use it from your phone (same Wi-Fi)
+
+Find your Mac's LAN IP and open `http://<that-ip>:3939` on the phone:
+
+```bash
+ipconfig getifaddr en0     # e.g. 192.168.1.42  ->  http://192.168.1.42:3939
+```
+
+Camera capture and clipboard work over plain HTTP on a LAN for most phones; if
+your browser insists on HTTPS for the camera, use the "choose an image" option
+or put it behind a tunnel (e.g. `cloudflared`, `ngrok`, or Tailscale).
+
+## Google API key (optional)
+
+1. In Google Cloud, enable **Cloud Vision API** and **Cloud Translation API**.
+2. Create an **API key** under *APIs & Services → Credentials*.
+3. `export GOOGLE_API_KEY=...` before `npm start` (or put it in a `.env` and
+   `export $(cat .env | xargs)`).
+
+Without a key the app still works end to end: Tesseract.js does the OCR and you
+get furigana + per-word definitions; only the full-sentence Google translation
+is skipped.

--- a/jp-reader/native/ocr.swift
+++ b/jp-reader/native/ocr.swift
@@ -1,0 +1,53 @@
+// Native macOS OCR via the Vision framework. Free, local, no API key.
+// Reads an image file path, prints recognized text (one observation per line).
+// Uses the modern RecognizeTextRequest (macOS 15+) which handles VERTICAL Japanese
+// (novels/manga); falls back to VNRecognizeTextRequest on older systems.
+// Build: swiftc -O native/ocr.swift -o bin/mac-ocr
+import Foundation
+import Vision
+import AppKit
+
+guard CommandLine.arguments.count > 1 else {
+  FileHandle.standardError.write("usage: mac-ocr <image-path>\n".data(using: .utf8)!)
+  exit(2)
+}
+let path = CommandLine.arguments[1]
+guard let img = NSImage(contentsOfFile: path),
+      let cg = img.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+  FileHandle.standardError.write("cannot load image\n".data(using: .utf8)!)
+  exit(1)
+}
+
+func fail(_ msg: String) -> Never {
+  FileHandle.standardError.write((msg + "\n").data(using: .utf8)!)
+  exit(1)
+}
+
+if #available(macOS 15.0, *) {
+  let sem = DispatchSemaphore(value: 0)
+  Task {
+    do {
+      var req = RecognizeTextRequest()
+      req.recognitionLanguages = [Locale.Language(identifier: "ja"), Locale.Language(identifier: "en")]
+      req.usesLanguageCorrection = true
+      req.recognitionLevel = .accurate
+      let results = try await req.perform(on: cg)
+      let lines = results.compactMap { $0.topCandidates(1).first?.string }
+      print(lines.joined(separator: "\n"))
+    } catch {
+      fail("ocr failed: \(error)")
+    }
+    sem.signal()
+  }
+  sem.wait()
+} else {
+  let request = VNRecognizeTextRequest { req, _ in
+    let obs = (req.results as? [VNRecognizedTextObservation]) ?? []
+    print(obs.compactMap { $0.topCandidates(1).first?.string }.joined(separator: "\n"))
+  }
+  request.recognitionLevel = .accurate
+  request.recognitionLanguages = ["ja", "en"]
+  request.usesLanguageCorrection = true
+  let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+  do { try handler.perform([request]) } catch { fail("ocr failed: \(error)") }
+}

--- a/jp-reader/package-lock.json
+++ b/jp-reader/package-lock.json
@@ -1,0 +1,870 @@
+{
+  "name": "jp-reader",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jp-reader",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.19.2",
+        "kuromoji": "^0.1.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/jp-reader/package.json
+++ b/jp-reader/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "jp-reader",
+  "version": "1.0.0",
+  "description": "Photograph a Japanese page, highlight a phrase, get furigana + definition + translation.",
+  "type": "commonjs",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js",
+    "build": "swiftc -O native/ocr.swift -o bin/mac-ocr",
+    "postinstall": "node -e \"if(process.platform==='darwin'){try{require('fs').mkdirSync('bin',{recursive:true});require('child_process').execFileSync('swiftc',['-O','native/ocr.swift','-o','bin/mac-ocr']);console.log('built bin/mac-ocr (Apple Vision OCR)')}catch(e){console.log('mac-ocr build skipped:',e.message)}}\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "kuromoji": "^0.1.2"
+  }
+}

--- a/jp-reader/public/app.js
+++ b/jp-reader/public/app.js
@@ -1,0 +1,463 @@
+'use strict';
+
+const $ = (id) => document.getElementById(id);
+const state = {
+  config: null,
+  text: '',
+  spans: [],        // spans[offset] = <span class="ch"> (null for newlines)
+  editing: false,
+  ocrBusy: false,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
+}
+
+let toastTimer;
+function toast(msg) {
+  const t = $('toast');
+  t.textContent = msg;
+  t.hidden = false;
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => (t.hidden = true), 3400);
+}
+
+function setStatus(el, html) {
+  if (html == null) { el.hidden = true; el.innerHTML = ''; }
+  else { el.hidden = false; el.innerHTML = html; }
+}
+const spinner = (text) => `<span class="spinner"></span><span>${escapeHtml(text)}</span>`;
+
+function cleanJp(text) {
+  return text
+    .replace(/[ \t]+/g, ' ')
+    .replace(/([^\x00-\x7F])\s+(?=[^\x00-\x7F])/g, '$1')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function renderFurigana(tokens) {
+  let html = '';
+  for (const t of tokens) {
+    for (const part of t.ruby) {
+      html += part.rt
+        ? `<ruby>${escapeHtml(part.base)}<rt>${escapeHtml(part.rt)}</rt></ruby>`
+        : escapeHtml(part.base);
+    }
+  }
+  return html;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+async function loadConfig() {
+  try { state.config = await (await fetch('/api/config')).json(); }
+  catch { state.config = { serverOcr: false, ocrEngine: null, googleTranslate: false }; }
+  const badge = $('engine');
+  const names = { 'apple-vision': 'Apple Vision OCR', 'google-vision': 'Google Vision OCR' };
+  const ocr = names[state.config.ocrEngine] || 'On-device OCR';
+  badge.textContent = state.config.googleTranslate ? ocr + ' + Translate' : ocr;
+  if (state.config.ocrEngine) badge.classList.add('on');
+}
+
+// ---------------------------------------------------------------------------
+// OCR
+// ---------------------------------------------------------------------------
+function fileToDataURL(file) {
+  return new Promise((res, rej) => { const r = new FileReader(); r.onload = () => res(r.result); r.onerror = rej; r.readAsDataURL(file); });
+}
+function shrinkDataURL(dataURL, maxDim = 2200) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = Math.min(1, maxDim / Math.max(img.width, img.height));
+      if (scale === 1) return resolve(dataURL);
+      const c = document.createElement('canvas');
+      c.width = Math.round(img.width * scale); c.height = Math.round(img.height * scale);
+      c.getContext('2d').drawImage(img, 0, 0, c.width, c.height);
+      resolve(c.toDataURL('image/jpeg', 0.92));
+    };
+    img.onerror = () => resolve(dataURL);
+    img.src = dataURL;
+  });
+}
+
+let tessWorker = null;
+async function tesseractOcr(dataURL) {
+  if (typeof Tesseract === 'undefined') throw new Error('OCR library failed to load');
+  if (!tessWorker) {
+    setStatus($('ocr-status'), spinner('Loading Japanese OCR model (first run, ~15 MB)…'));
+    tessWorker = await Tesseract.createWorker('jpn', 1, {
+      logger: (m) => { if (m.status === 'recognizing text') setStatus($('ocr-status'), spinner(`Reading… ${Math.round(m.progress * 100)}%`)); },
+    });
+  }
+  setStatus($('ocr-status'), spinner('Reading text…'));
+  const { data } = await tessWorker.recognize(dataURL);
+  return data.text || '';
+}
+
+async function runOcr(dataURL) {
+  if (state.config && state.config.serverOcr) {
+    const label = state.config.ocrEngine === 'apple-vision' ? 'Apple Vision' : 'Google Vision';
+    setStatus($('ocr-status'), spinner(`Reading text with ${label}…`));
+    try {
+      const res = await fetch('/api/ocr', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ image: dataURL }) });
+      if (res.ok) { const j = await res.json(); if (!j.needFallback) return j.text || ''; }
+      else { const j = await res.json().catch(() => ({})); toast(`${label} failed, using on-device OCR. ` + (j.error || '')); }
+    } catch (e) { toast(`${label} unreachable, using on-device OCR.`); }
+  }
+  return tesseractOcr(dataURL);
+}
+
+async function handleFile(file) {
+  if (!file || state.ocrBusy) return;
+  state.ocrBusy = true;
+  try {
+    const raw = await fileToDataURL(file);
+    $('preview').src = raw;
+    $('preview-wrap').hidden = false;
+
+    const small = await shrinkDataURL(raw);
+    let text = cleanJp(await runOcr(small));
+
+    setStatus($('ocr-status'), null);
+    $('capture-card').classList.add('compact');
+    $('reader-card').hidden = false;
+    setReaderText(text);
+
+    if (!text) toast('No text detected. Try a sharper, closer photo — or tap Edit to type it.');
+    else $('reader-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } catch (err) {
+    console.error(err);
+    setStatus($('ocr-status'), null);
+    toast('OCR error: ' + err.message);
+  } finally {
+    state.ocrBusy = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reader rendering
+// ---------------------------------------------------------------------------
+function setReaderText(text) {
+  state.text = text;
+  const reader = $('reader');
+  reader.innerHTML = '';
+  state.spans = [];
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\n') { frag.appendChild(document.createElement('br')); state.spans[i] = null; continue; }
+    const span = document.createElement('span');
+    span.className = 'ch';
+    span.dataset.off = i;
+    span.textContent = ch;
+    state.spans[i] = span;
+    frag.appendChild(span);
+  }
+  reader.appendChild(frag);
+}
+
+// ---------------------------------------------------------------------------
+// Custom selection + floating bubbles
+// ---------------------------------------------------------------------------
+const sel = { active: false, deciding: false, touchId: null, startX: 0, startY: 0, startOff: null, a: -1, b: -1, lastA: -1, lastB: -1, current: '' };
+
+function charFromPoint(x, y) {
+  let parent = null;
+  if (document.caretRangeFromPoint) {
+    const r = document.caretRangeFromPoint(x, y);
+    if (r) { const n = r.startContainer; parent = n.nodeType === 3 ? n.parentElement : n; }
+  } else if (document.caretPositionFromPoint) {
+    const p = document.caretPositionFromPoint(x, y);
+    if (p) { const n = p.offsetNode; parent = n.nodeType === 3 ? n.parentElement : n; }
+  }
+  if (parent && parent.classList && parent.classList.contains('ch')) return +parent.dataset.off;
+  const el = document.elementFromPoint(x, y);
+  if (el && el.classList && el.classList.contains('ch')) return +el.dataset.off;
+  return null;
+}
+
+function clearHighlight() {
+  if (sel.lastA < 0) return;
+  for (let i = sel.lastA; i <= sel.lastB; i++) {
+    const s = state.spans[i];
+    if (s) s.classList.remove('sel', 'sel-start', 'sel-end');
+  }
+  sel.lastA = sel.lastB = -1;
+}
+
+function applyHighlight(a, b) {
+  if (a === sel.lastA && b === sel.lastB) return;
+  clearHighlight();
+  for (let i = a; i <= b; i++) { const s = state.spans[i]; if (s) s.classList.add('sel'); }
+  if (state.spans[a]) state.spans[a].classList.add('sel-start');
+  if (state.spans[b]) state.spans[b].classList.add('sel-end');
+  sel.lastA = a; sel.lastB = b;
+}
+
+function selectionRect(a, b) {
+  let left = Infinity, top = Infinity, right = -Infinity, bottom = -Infinity;
+  for (let i = a; i <= b; i++) {
+    const s = state.spans[i];
+    if (!s) continue;
+    const r = s.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) continue;
+    left = Math.min(left, r.left); top = Math.min(top, r.top);
+    right = Math.max(right, r.right); bottom = Math.max(bottom, r.bottom);
+  }
+  if (left === Infinity) return null;
+  return { left, top, right, bottom, cx: (left + right) / 2 };
+}
+
+function placeBubble(el, cx, desiredTop) {
+  const vw = window.innerWidth, vh = window.innerHeight, margin = 8;
+  const w = el.offsetWidth, h = el.offsetHeight;
+  const left = Math.max(margin, Math.min(Math.round(cx - w / 2), vw - w - margin));
+  const top = Math.round(Math.max(margin, Math.min(desiredTop, vh - h - margin)));
+  el.style.left = left + 'px';
+  el.style.top = top + 'px';
+}
+
+// Stack both bubbles above the phrase: [ translation ] / [ furigana ] / phrase.
+// If there isn't room above, stack below — translation still just above furigana.
+function positionBubbles(a, b) {
+  const rect = selectionRect(a, b);
+  if (!rect) return;
+  const furi = $('bubble-furi'), trans = $('bubble-trans');
+  const gap = 10, pair = 8, margin = 8;
+  const fH = furi.offsetHeight, tH = trans.offsetHeight;
+  const unit = tH + pair + fH;
+  let furiTop, transTop;
+  if (rect.top - gap - unit >= margin) {
+    furiTop = rect.top - gap - fH;
+    transTop = furiTop - pair - tH;
+  } else {
+    transTop = rect.bottom + gap;
+    furiTop = transTop + tH + pair;
+  }
+  placeBubble(furi, rect.cx, furiTop);
+  placeBubble(trans, rect.cx, transTop);
+}
+
+let showFrame;
+function showBubbles() {
+  const furi = $('bubble-furi'), trans = $('bubble-trans');
+  furi.hidden = false; trans.hidden = false;
+  cancelAnimationFrame(showFrame);
+  showFrame = requestAnimationFrame(() => { furi.classList.add('show'); trans.classList.add('show'); });
+}
+let hideTimer;
+function hideBubbles() {
+  const furi = $('bubble-furi'), trans = $('bubble-trans');
+  furi.classList.remove('show'); trans.classList.remove('show');
+  clearTimeout(hideTimer);
+  hideTimer = setTimeout(() => { furi.hidden = true; trans.hidden = true; }, 140);
+}
+
+// ----- content + debounced data fetching -----
+const furiCache = new Map();
+const meanCache = new Map();
+let furiCtl = null, meanCtl = null, furiTimer = 0, meanTimer = 0;
+
+function renderFuri(text, html) {
+  $('bubble-furi').innerHTML = `<div class="furi">${html != null ? html : escapeHtml(text)}</div>`;
+}
+function renderTrans(meaning) {
+  const bot = $('bubble-trans');
+  if (!meaning) { bot.innerHTML = `<div class="b-translation loading">…</div>`; bot.hidden = false; return; }
+  let parts = '';
+  if (meaning.translation) parts += `<div class="b-translation">${escapeHtml(meaning.translation)}</div>`;
+  const words = (meaning.words || []).slice(0, 2);
+  if (words.length) {
+    const rows = words.map((w) => {
+      const r = w.reading ? `<span class="r">（${escapeHtml(w.reading)}）</span>` : '';
+      const def = (w.senses[0] && w.senses[0].definitions.slice(0, 3).join('; ')) || '';
+      return `<div class="b-word"><b>${escapeHtml(w.word)}</b>${r} ${escapeHtml(def)}</div>`;
+    }).join('');
+    parts += `<div class="b-words">${rows}</div>`;
+  }
+  if (!parts) parts = `<div class="b-hint">${state.config.googleTranslate ? 'No definition found.' : 'No dictionary match.'}</div>`;
+  bot.innerHTML = parts;
+}
+
+function requestData(text) {
+  // Furigana — fast, local.
+  clearTimeout(furiTimer);
+  if (furiCache.has(text)) renderFuri(text, furiCache.get(text));
+  else {
+    renderFuri(text, null);
+    furiTimer = setTimeout(async () => {
+      try {
+        if (furiCtl) furiCtl.abort();
+        furiCtl = new AbortController();
+        const res = await fetch('/api/furigana', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text }), signal: furiCtl.signal });
+        if (!res.ok) return;
+        const j = await res.json();
+        const html = renderFurigana(j.tokens);
+        furiCache.set(text, html);
+        if (sel.current === text) { renderFuri(text, html); positionBubbles(sel.a, sel.b); }
+      } catch (e) { if (e.name !== 'AbortError') console.warn('furigana', e.message); }
+    }, 80);
+  }
+
+  // Meaning — slower, network.
+  clearTimeout(meanTimer);
+  if (meanCache.has(text)) renderTrans(meanCache.get(text));
+  else {
+    renderTrans(null);
+    meanTimer = setTimeout(async () => {
+      try {
+        if (meanCtl) meanCtl.abort();
+        meanCtl = new AbortController();
+        const res = await fetch('/api/meaning', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text }), signal: meanCtl.signal });
+        if (!res.ok) return;
+        const j = await res.json();
+        meanCache.set(text, j);
+        if (sel.current === text) { renderTrans(j); positionBubbles(sel.a, sel.b); }
+      } catch (e) { if (e.name !== 'AbortError') console.warn('meaning', e.message); }
+    }, 300);
+  }
+}
+
+function updateSelection(off) {
+  const a = Math.min(sel.startOff, off);
+  const b = Math.max(sel.startOff, off);
+  sel.a = a; sel.b = b;
+  applyHighlight(a, b);
+  // Multi-line phrase: drop line breaks so the reading/translation treat it as one phrase.
+  const text = state.text.slice(a, b + 1).replace(/\n/g, '').trim();
+  if (text && text !== sel.current) { sel.current = text; requestData(text); }
+  positionBubbles(a, b); // after content is set, so width/height are measured correctly
+}
+
+// ----- gesture layer -----
+// Mouse: any drag selects. Touch: a horizontal drag selects; a vertical drag falls
+// through to the browser's native (momentum) scrolling. We use touch events rather
+// than pointer events because preventDefault() on the first horizontal touchmove
+// reliably locks the gesture to selection, while never touching vertical scrolls —
+// so normal scrolling keeps its native feel and selection never breaks.
+
+function beginSelecting() {
+  if (sel.startOff == null) sel.startOff = charFromPoint(sel.startX, sel.startY);
+  if (sel.startOff == null) return false;
+  sel.deciding = false;
+  sel.active = true;
+  sel.current = '';
+  renderFuri('', null);
+  renderTrans(null);
+  showBubbles();
+  return true;
+}
+
+function endGesture(wasSelecting) {
+  sel.active = false; sel.deciding = false; sel.touchId = null; sel.startOff = null;
+  sel.a = sel.b = -1; sel.current = '';
+  if (wasSelecting) { hideBubbles(); clearHighlight(); }
+}
+
+// --- mouse ---
+function onMouseDown(e) {
+  if (state.editing || e.button !== 0 || sel.active || sel.deciding) return;
+  sel.deciding = true;
+  sel.startX = e.clientX; sel.startY = e.clientY;
+  sel.startOff = charFromPoint(e.clientX, e.clientY);
+  window.addEventListener('mousemove', onMouseMove);
+  window.addEventListener('mouseup', onMouseUp);
+}
+function onMouseMove(e) {
+  if (sel.deciding) {
+    if (Math.abs(e.clientX - sel.startX) + Math.abs(e.clientY - sel.startY) < 4) return;
+    if (!beginSelecting()) return onMouseUp();
+  }
+  if (sel.active) { const off = charFromPoint(e.clientX, e.clientY); if (off != null) updateSelection(off); }
+}
+function onMouseUp() {
+  window.removeEventListener('mousemove', onMouseMove);
+  window.removeEventListener('mouseup', onMouseUp);
+  endGesture(sel.active);
+}
+
+// --- touch ---
+function trackedTouch(e) {
+  for (const t of e.changedTouches) if (t.identifier === sel.touchId) return t;
+  return null;
+}
+function onTouchStart(e) {
+  if (state.editing || sel.active || sel.deciding) return;
+  const t = e.changedTouches[0];
+  sel.touchId = t.identifier;
+  sel.deciding = true;
+  sel.startX = t.clientX; sel.startY = t.clientY;
+  sel.startOff = charFromPoint(t.clientX, t.clientY);
+}
+function onTouchMove(e) {
+  if (!sel.deciding && !sel.active) return;
+  const t = trackedTouch(e);
+  if (!t) return;
+  if (sel.deciding) {
+    const dx = t.clientX - sel.startX, dy = t.clientY - sel.startY;
+    if (Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
+    if (Math.abs(dx) > Math.abs(dy)) {            // horizontal → select
+      if (!beginSelecting()) { sel.deciding = false; sel.touchId = null; return; }
+    } else {                                       // vertical → let the browser scroll natively
+      sel.deciding = false; sel.touchId = null;
+      return;
+    }
+  }
+  if (sel.active) {
+    e.preventDefault();                            // keep the page from scrolling while selecting
+    const off = charFromPoint(t.clientX, t.clientY);
+    if (off != null) updateSelection(off);
+  }
+}
+function onTouchEnd(e) {
+  if (sel.touchId == null || !trackedTouch(e)) return;
+  const wasSelecting = sel.active;
+  if (wasSelecting) e.preventDefault();            // suppress the synthesized ghost click
+  endGesture(wasSelecting);
+}
+
+// ---------------------------------------------------------------------------
+// Edit / retake wiring
+// ---------------------------------------------------------------------------
+function toggleEdit() {
+  const reader = $('reader'), editor = $('editor'), btn = $('edit-toggle');
+  if (!state.editing) {
+    state.editing = true;
+    hideBubbles(); clearHighlight();
+    editor.value = state.text;
+    editor.hidden = false;
+    reader.style.display = 'none';
+    btn.textContent = 'Done';
+    editor.focus();
+  } else {
+    state.editing = false;
+    editor.hidden = true;
+    reader.style.display = '';
+    btn.textContent = 'Edit';
+    setReaderText(editor.value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wire up
+// ---------------------------------------------------------------------------
+$('file').addEventListener('change', (e) => { handleFile(e.target.files[0]); e.target.value = ''; });
+$('retake').addEventListener('click', () => $('file').click());
+$('edit-toggle').addEventListener('click', toggleEdit);
+$('reader').addEventListener('mousedown', onMouseDown);
+$('reader').addEventListener('touchstart', onTouchStart, { passive: true });
+$('reader').addEventListener('touchmove', onTouchMove, { passive: false });
+$('reader').addEventListener('touchend', onTouchEnd);
+$('reader').addEventListener('touchcancel', onTouchEnd);
+$('reader').addEventListener('contextmenu', (e) => e.preventDefault());
+window.addEventListener('resize', () => { if (sel.active) positionBubbles(sel.a, sel.b); });
+
+loadConfig();

--- a/jp-reader/public/index.html
+++ b/jp-reader/public/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+  <meta name="theme-color" content="#0f1115" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <title>読む · Japanese Reader</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>読む<span class="sub">Japanese Reader</span></h1>
+    <span id="engine" class="engine" title="OCR / translation engine"></span>
+  </header>
+
+  <main>
+    <!-- Capture -->
+    <section class="card capture" id="capture-card">
+      <label for="file" class="shoot">
+        <span class="cam">📷</span>
+        <span class="shoot-label">Take a photo of the page</span>
+        <span class="shoot-hint">or choose an image</span>
+      </label>
+      <input id="file" type="file" accept="image/*" capture="environment" hidden />
+      <div id="preview-wrap" class="preview-wrap" hidden>
+        <img id="preview" alt="captured page" />
+        <button id="retake" class="retake" type="button">Retake</button>
+      </div>
+      <div id="ocr-status" class="status" hidden></div>
+    </section>
+
+    <!-- Reader -->
+    <section id="reader-card" class="card reader-card" hidden>
+      <div class="reader-head">
+        <span class="hint" id="reader-hint">Drag a finger across the text — reading floats above, meaning below. Lift to dismiss.</span>
+        <button id="edit-toggle" class="ghost" type="button">Edit</button>
+      </div>
+      <div id="reader" class="reader" lang="ja"></div>
+      <textarea id="editor" class="editor" hidden spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+    </section>
+  </main>
+
+  <!-- Floating popovers (positioned in JS, follow the selection).
+       Stacked above the phrase: translation on top, furigana just above the text. -->
+  <div id="bubble-trans" class="bubble" hidden></div>
+  <div id="bubble-furi" class="bubble" hidden></div>
+
+  <div id="toast" class="toast" hidden></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/jp-reader/public/style.css
+++ b/jp-reader/public/style.css
@@ -1,0 +1,159 @@
+:root {
+  --bg: #0f1115;
+  --card: #181b22;
+  --card-2: #1f232c;
+  --line: #2a2f3a;
+  --text: #eef1f6;
+  --muted: #9aa3b2;
+  --accent: #6ea8fe;
+  --accent-2: #4f8cff;
+  --good: #5ad19a;
+  --warn: #f0b35b;
+  --sel: rgba(110, 168, 254, 0.30);
+}
+
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+
+html, body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  overscroll-behavior-y: none;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: calc(env(safe-area-inset-top) + 14px) 18px 14px;
+  background: linear-gradient(180deg, rgba(15,17,21,0.96), rgba(15,17,21,0.82));
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+.topbar h1 { margin: 0; font-size: 22px; letter-spacing: 1px; display: flex; align-items: baseline; gap: 10px; }
+.topbar .sub { font-size: 12px; font-weight: 500; color: var(--muted); letter-spacing: 0.3px; }
+.engine { font-size: 11px; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 3px 9px; white-space: nowrap; }
+.engine.on { color: var(--good); border-color: rgba(90,209,154,0.4); }
+
+main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 16px 16px calc(env(safe-area-inset-bottom) + 60px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 16px; position: relative; }
+
+/* ---- capture ---- */
+.shoot { display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 26px 16px; border: 1.5px dashed var(--line); border-radius: 14px; cursor: pointer; transition: border-color .15s, background .15s; }
+.shoot:active { background: var(--card-2); border-color: var(--accent); }
+.shoot .cam { font-size: 38px; }
+.shoot-label { font-size: 16px; font-weight: 600; }
+.shoot-hint { font-size: 13px; color: var(--muted); }
+.capture.compact .shoot { padding: 14px; }
+.capture.compact .cam { font-size: 24px; }
+
+.preview-wrap { margin-top: 14px; border-radius: 12px; overflow: hidden; border: 1px solid var(--line); background: #000; position: relative; }
+.preview-wrap img { display: block; width: 100%; height: auto; max-height: 34vh; object-fit: contain; }
+.retake { position: absolute; top: 8px; right: 8px; background: rgba(0,0,0,0.6); color: var(--text); border: 1px solid var(--line); border-radius: 9px; padding: 6px 11px; font-size: 13px; cursor: pointer; }
+
+.status { margin-top: 12px; font-size: 14px; color: var(--muted); display: flex; align-items: center; gap: 9px; }
+.status .spinner { width: 15px; height: 15px; border: 2px solid var(--line); border-top-color: var(--accent); border-radius: 50%; animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ---- reader ---- */
+.reader-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.hint { font-size: 12.5px; color: var(--muted); line-height: 1.4; }
+.ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); border-radius: 9px; padding: 6px 13px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; }
+.ghost:active { background: var(--card-2); }
+
+.reader {
+  font-family: "Hiragino Mincho ProN", "Noto Serif JP", "Yu Mincho", serif;
+  font-size: 27px;
+  line-height: 2.05;
+  color: var(--text);
+  touch-action: pan-y;                 /* vertical drag = native momentum scroll; horizontal = our selection */
+  -webkit-user-select: none; user-select: none;
+  -webkit-touch-callout: none;
+  cursor: text;
+  word-break: break-all;
+  min-height: 80px;
+}
+.reader .ch { display: inline-block; position: relative; }
+.reader .ch.sel { background: var(--sel); }
+.reader .ch.sel-start { border-top-left-radius: 6px; border-bottom-left-radius: 6px; }
+.reader .ch.sel-end { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
+
+.editor {
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  background: var(--card-2);
+  color: var(--text);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  padding: 14px;
+  font-size: 22px;
+  line-height: 1.9;
+  font-family: "Hiragino Mincho ProN", "Noto Serif JP", "Yu Mincho", serif;
+}
+.editor:focus { outline: none; }
+
+/* ---- floating bubbles ---- */
+.bubble {
+  position: fixed;
+  z-index: 50;
+  pointer-events: none;
+  max-width: min(86vw, 460px);
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(28, 32, 41, 0.92);
+  border: 1px solid rgba(255,255,255,0.10);
+  box-shadow: 0 10px 34px rgba(0,0,0,0.5);
+  backdrop-filter: blur(14px) saturate(1.2);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  text-align: center;
+  opacity: 0;
+  transform: translateY(3px) scale(0.98);
+  transition: opacity .12s ease, transform .12s ease;
+  will-change: transform, opacity, left, top;
+}
+.bubble.show { opacity: 1; transform: translateY(0) scale(1); }
+#bubble-furi { background: rgba(24, 28, 37, 0.94); }
+
+/* furigana bubble */
+.furi {
+  font-family: "Hiragino Mincho ProN", "Noto Serif JP", "Yu Mincho", serif;
+  font-size: 25px;
+  line-height: 2.0;
+  white-space: normal;        /* wrap long / multi-line phrases */
+  word-break: break-all;
+}
+.furi ruby { margin: 0 1px; }
+.furi rt { font-size: 0.44em; color: var(--accent); font-family: -apple-system, "Noto Sans JP", sans-serif; font-weight: 700; line-height: 1; }
+.furi.kana-only { color: var(--accent); }
+
+/* bottom bubble — meaning */
+.b-translation { font-size: 17px; font-weight: 650; line-height: 1.35; }
+.b-translation.loading { color: var(--muted); font-weight: 400; }
+.b-words { margin-top: 7px; display: flex; flex-direction: column; gap: 4px; }
+.b-word { font-size: 13.5px; color: var(--muted); line-height: 1.35; text-align: center; }
+.b-word b { color: var(--text); font-weight: 600; }
+.b-word .r { color: var(--accent); }
+.b-hint { font-size: 12px; color: var(--muted); }
+
+.toast {
+  position: fixed; left: 50%; bottom: calc(env(safe-area-inset-bottom) + 22px);
+  transform: translateX(-50%);
+  background: #2a2f3a; color: var(--text); border: 1px solid var(--line);
+  padding: 11px 16px; border-radius: 10px; font-size: 14px; max-width: 90vw; z-index: 60;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
+}

--- a/jp-reader/server.js
+++ b/jp-reader/server.js
@@ -1,0 +1,380 @@
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const crypto = require('crypto');
+const { execFile } = require('child_process');
+const express = require('express');
+const kuromoji = require('kuromoji');
+
+const app = express();
+const PORT = process.env.PORT || 3939;
+const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY || process.env.GOOGLE_TRANSLATE_API_KEY || '';
+
+// Native macOS Vision OCR (free, local). Available when running on macOS and the
+// compiled helper exists. `OCR_ENGINE=google` forces Google Vision instead.
+const MAC_OCR_BIN = path.join(__dirname, 'bin', 'mac-ocr');
+const MAC_OCR_AVAILABLE = process.platform === 'darwin' && fs.existsSync(MAC_OCR_BIN);
+const FORCE_GOOGLE = (process.env.OCR_ENGINE || '').toLowerCase() === 'google';
+const OCR_ENGINE =
+  (!FORCE_GOOGLE && MAC_OCR_AVAILABLE) ? 'apple-vision' : (GOOGLE_API_KEY ? 'google-vision' : null);
+
+app.use(express.json({ limit: '20mb' }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+// ---------------------------------------------------------------------------
+// Kuromoji tokenizer (built once at startup, reused for every request)
+// ---------------------------------------------------------------------------
+let tokenizer = null;
+let tokenizerError = null;
+
+kuromoji
+  .builder({ dicPath: path.join(__dirname, 'node_modules', 'kuromoji', 'dict') })
+  .build((err, tk) => {
+    if (err) {
+      tokenizerError = err;
+      console.error('Failed to build kuromoji tokenizer:', err);
+      return;
+    }
+    tokenizer = tk;
+    console.log('kuromoji tokenizer ready');
+  });
+
+// ---------------------------------------------------------------------------
+// Japanese text helpers
+// ---------------------------------------------------------------------------
+const KANJI_RE = /[一-龯㐀-䶿豈-﫿]/;
+
+function hasKanji(s) {
+  return KANJI_RE.test(s);
+}
+
+function kataToHira(s) {
+  if (!s) return '';
+  return s.replace(/[ァ-ヶ]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0x60));
+}
+
+// Build okurigana-aware ruby for a single token.
+// Returns { surface, reading, ruby:[{base, rt}] } where rt is '' for kana runs.
+function rubyForToken(surface, readingKata) {
+  const reading = kataToHira(readingKata || '');
+  if (!hasKanji(surface) || !reading) {
+    return { surface, reading, ruby: [{ base: surface, rt: '' }] };
+  }
+
+  // Strip matching leading kana (non-kanji surface chars that equal the reading).
+  let pre = 0;
+  while (
+    pre < surface.length &&
+    pre < reading.length &&
+    !KANJI_RE.test(surface[pre]) &&
+    surface[pre] === reading[pre]
+  ) {
+    pre++;
+  }
+
+  // Strip matching trailing kana (okurigana).
+  let suf = 0;
+  while (
+    suf < surface.length - pre &&
+    suf < reading.length - pre &&
+    !KANJI_RE.test(surface[surface.length - 1 - suf]) &&
+    surface[surface.length - 1 - suf] === reading[reading.length - 1 - suf]
+  ) {
+    suf++;
+  }
+
+  const lead = surface.slice(0, pre);
+  const core = surface.slice(pre, surface.length - suf);
+  const tail = suf === 0 ? '' : surface.slice(surface.length - suf);
+  const coreReading = reading.slice(pre, reading.length - suf);
+
+  const parts = [];
+  if (lead) parts.push({ base: lead, rt: '' });
+  if (core) parts.push({ base: core, rt: hasKanji(core) ? coreReading : '' });
+  if (tail) parts.push({ base: tail, rt: '' });
+  return { surface, reading, ruby: parts };
+}
+
+// Parts of speech worth looking up in the dictionary.
+const CONTENT_POS = new Set(['名詞', '動詞', '形容詞', '副詞', '形容動詞', '連体詞']);
+
+function analyzeText(text) {
+  if (!tokenizer) throw new Error('tokenizer not ready');
+  const tokens = tokenizer.tokenize(text);
+  const out = tokens.map((t) => {
+    const surface = t.surface_form;
+    const base = t.basic_form && t.basic_form !== '*' ? t.basic_form : surface;
+    const readingKata = t.reading && t.reading !== '*' ? t.reading : '';
+    const r = rubyForToken(surface, readingKata);
+    return {
+      surface,
+      base,
+      reading: r.reading,
+      pos: t.pos,
+      pos_detail: t.pos_detail_1,
+      ruby: r.ruby,
+      // Worth a dictionary lookup: content words, skipping non-independent
+      // helpers, numbers, and bare suffixes.
+      lookup:
+        CONTENT_POS.has(t.pos) &&
+        t.pos_detail_1 !== '非自立' &&
+        t.pos_detail_1 !== '数' &&
+        t.pos_detail_1 !== '接尾',
+    };
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// External services
+// ---------------------------------------------------------------------------
+async function withTimeout(promise, ms, label) {
+  let timer;
+  const t = new Promise((_, rej) => {
+    timer = setTimeout(() => rej(new Error(`${label} timed out`)), ms);
+  });
+  try {
+    return await Promise.race([promise, t]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Jisho.org unofficial API — dictionary definitions (proxied to avoid CORS).
+async function jishoLookup(word) {
+  const url = `https://jisho.org/api/v1/search/words?keyword=${encodeURIComponent(word)}`;
+  const res = await withTimeout(fetch(url), 8000, 'jisho');
+  if (!res.ok) throw new Error(`jisho ${res.status}`);
+  const json = await res.json();
+  const first = (json.data || [])[0];
+  if (!first) return null;
+  const jp = (first.japanese || [])[0] || {};
+  const senses = (first.senses || []).slice(0, 3).map((s) => ({
+    definitions: s.english_definitions || [],
+    pos: s.parts_of_speech || [],
+  }));
+  return {
+    word: jp.word || word,
+    reading: jp.reading || '',
+    is_common: !!first.is_common,
+    senses,
+  };
+}
+
+// Google Translate API v2 (REST, API-key auth).
+async function googleTranslate(text, target = 'en', source = 'ja') {
+  if (!GOOGLE_API_KEY) return null;
+  const url = `https://translation.googleapis.com/language/translate/v2?key=${GOOGLE_API_KEY}`;
+  const res = await withTimeout(
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, target, source, format: 'text' }),
+    }),
+    8000,
+    'translate'
+  );
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`google translate ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = await res.json();
+  return json?.data?.translations?.[0]?.translatedText || null;
+}
+
+// Native macOS Vision OCR — writes the image to a temp file and runs the helper.
+function appleVisionOcr(base64, mime) {
+  return new Promise((resolve, reject) => {
+    const ext = /jpe?g/.test(mime || '') ? 'jpg' : 'png';
+    const tmp = path.join(os.tmpdir(), `jpreader-${crypto.randomUUID()}.${ext}`);
+    fs.writeFile(tmp, Buffer.from(base64, 'base64'), (werr) => {
+      if (werr) return reject(werr);
+      execFile(MAC_OCR_BIN, [tmp], { timeout: 15000, maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+        fs.unlink(tmp, () => {});
+        if (err) return reject(new Error(`mac-ocr: ${stderr || err.message}`));
+        resolve((stdout || '').trim());
+      });
+    });
+  });
+}
+
+// Google Cloud Vision OCR (TEXT_DETECTION, API-key auth).
+async function googleVisionOcr(base64) {
+  if (!GOOGLE_API_KEY) return null;
+  const url = `https://vision.googleapis.com/v1/images:annotate?key=${GOOGLE_API_KEY}`;
+  const res = await withTimeout(
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [
+          {
+            image: { content: base64 },
+            features: [{ type: 'DOCUMENT_TEXT_DETECTION' }],
+            imageContext: { languageHints: ['ja'] },
+          },
+        ],
+      }),
+    }),
+    15000,
+    'vision'
+  );
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`google vision ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = await res.json();
+  const r = json?.responses?.[0];
+  if (r?.error) throw new Error(`google vision: ${r.error.message}`);
+  return r?.fullTextAnnotation?.text || '';
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+app.get('/api/config', (_req, res) => {
+  res.json({
+    ocrEngine: OCR_ENGINE,                 // 'apple-vision' | 'google-vision' | null
+    serverOcr: !!OCR_ENGINE,
+    googleTranslate: !!GOOGLE_API_KEY,
+    tokenizerReady: !!tokenizer,
+  });
+});
+
+app.post('/api/ocr', async (req, res) => {
+  try {
+    let { image } = req.body || {};
+    if (!image) return res.status(400).json({ error: 'missing image' });
+    // Accept data URLs or raw base64.
+    let mime = '';
+    if (image.startsWith('data:')) {
+      const comma = image.indexOf(',');
+      mime = image.slice(5, image.indexOf(';'));
+      if (comma !== -1) image = image.slice(comma + 1);
+    }
+
+    if (!OCR_ENGINE) {
+      return res.status(200).json({ text: '', source: 'none', needFallback: true });
+    }
+    const text = OCR_ENGINE === 'apple-vision'
+      ? await appleVisionOcr(image, mime)
+      : await googleVisionOcr(image);
+    res.json({ text, source: OCR_ENGINE });
+  } catch (err) {
+    console.error('ocr error:', err.message);
+    res.status(502).json({ error: err.message });
+  }
+});
+
+app.post('/api/analyze', async (req, res) => {
+  try {
+    const text = (req.body && req.body.text ? String(req.body.text) : '').trim();
+    if (!text) return res.status(400).json({ error: 'missing text' });
+    if (!tokenizer) {
+      return res.status(503).json({ error: tokenizerError ? 'tokenizer failed to load' : 'tokenizer warming up' });
+    }
+    if (text.length > 400) {
+      return res.status(413).json({ error: 'phrase too long (max 400 chars)' });
+    }
+
+    const tokens = analyzeText(text);
+
+    // Unique dictionary-form lookups for content words (cap to keep it snappy).
+    const seen = new Set();
+    const lookups = [];
+    for (const t of tokens) {
+      if (!t.lookup) continue;
+      const key = t.base || t.surface;
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      lookups.push(key);
+      if (lookups.length >= 10) break;
+    }
+
+    const [translation, ...wordResults] = await Promise.all([
+      googleTranslate(text).catch((e) => {
+        console.warn('translate failed:', e.message);
+        return null;
+      }),
+      ...lookups.map((w) =>
+        jishoLookup(w).catch((e) => {
+          console.warn(`jisho "${w}" failed:`, e.message);
+          return null;
+        })
+      ),
+    ]);
+
+    const words = wordResults.filter(Boolean);
+
+    res.json({
+      text,
+      tokens,
+      words,
+      translation,
+      translationSource: translation ? 'google' : null,
+    });
+  } catch (err) {
+    console.error('analyze error:', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Fast path: tokenize only (kuromoji, no network) so furigana feels instant.
+app.post('/api/furigana', (req, res) => {
+  try {
+    const text = (req.body && req.body.text ? String(req.body.text) : '').trim();
+    if (!text) return res.status(400).json({ error: 'missing text' });
+    if (!tokenizer) return res.status(503).json({ error: 'tokenizer warming up' });
+    if (text.length > 400) return res.status(413).json({ error: 'phrase too long' });
+    res.json({ text, tokens: analyzeText(text) });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Slower path: translation + dictionary definitions (network-bound).
+app.post('/api/meaning', async (req, res) => {
+  try {
+    const text = (req.body && req.body.text ? String(req.body.text) : '').trim();
+    if (!text) return res.status(400).json({ error: 'missing text' });
+    if (!tokenizer) return res.status(503).json({ error: 'tokenizer warming up' });
+    if (text.length > 400) return res.status(413).json({ error: 'phrase too long' });
+
+    const tokens = analyzeText(text);
+    const seen = new Set();
+    const lookups = [];
+    for (const t of tokens) {
+      if (!t.lookup) continue;
+      const key = t.base || t.surface;
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      lookups.push(key);
+      if (lookups.length >= 6) break;
+    }
+
+    const [translation, ...wordResults] = await Promise.all([
+      googleTranslate(text).catch((e) => {
+        console.warn('translate failed:', e.message);
+        return null;
+      }),
+      ...lookups.map((w) => jishoLookup(w).catch(() => null)),
+    ]);
+
+    res.json({
+      text,
+      translation,
+      translationSource: translation ? 'google' : null,
+      words: wordResults.filter(Boolean),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`jp-reader listening on http://localhost:${PORT}`);
+  console.log(`OCR engine: ${OCR_ENGINE || 'none (browser Tesseract.js fallback)'}`);
+  console.log(`Translation: ${GOOGLE_API_KEY ? 'Google Translate enabled' : 'off (no Google key) — word definitions only'}`);
+});


### PR DESCRIPTION
A new standalone project under `jp-reader/`.

**What it does:** open it on your phone, photograph a page of Japanese, drag a finger across any phrase — the reading (furigana) floats above the phrase and the translation/definition below it, and it dismisses when you lift your finger.

**Engines**
- **OCR:** native **Apple Vision** (macOS, local, free, no key) via a tiny Swift helper (`native/ocr.swift`). Uses the modern `RecognizeTextRequest` API, so it reads **both horizontal and vertical** Japanese. Falls back to Google Cloud Vision (`GOOGLE_API_KEY`), then in-browser Tesseract.js.
- **Furigana:** `kuromoji`, okurigana-aware, fully local.
- **Definitions:** Jisho/JMdict dictionary lookup.
- **Translation:** Google Translate API when a key is set.

**Run:** `cd jp-reader && npm install && npm start` → http://localhost:3939 (`npm install` compiles the Swift OCR helper on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)